### PR TITLE
Project setup & base navigation (Issue 2)

### DIFF
--- a/app/src/main/java/com/example/studentcenterapp/MainActivity.kt
+++ b/app/src/main/java/com/example/studentcenterapp/MainActivity.kt
@@ -3,45 +3,14 @@ package com.example.studentcenterapp
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
-import com.example.studentcenterapp.ui.theme.StudentCenterAppTheme
+import com.example.studentcenterapp.navigation.StudentCenterApp
 
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
+
         setContent {
-            StudentCenterAppTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Hello",
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }
-            }
+            StudentCenterApp()
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    StudentCenterAppTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/com/example/studentcenterapp/navigation/Screen.kt
+++ b/app/src/main/java/com/example/studentcenterapp/navigation/Screen.kt
@@ -1,0 +1,11 @@
+package com.example.studentcenterapp.navigation
+
+sealed class Screen(val route: String) {
+    object Splash : Screen("splash")
+    object Departments : Screen("departments")
+    object Services : Screen("services")
+    object Slots : Screen("slots")
+    object Confirm : Screen("confirm")
+    object Appointments : Screen("appointments")
+    object StaffDashboard : Screen("staffDashboard")
+}

--- a/app/src/main/java/com/example/studentcenterapp/navigation/StudentCenterNavHost.kt
+++ b/app/src/main/java/com/example/studentcenterapp/navigation/StudentCenterNavHost.kt
@@ -1,0 +1,73 @@
+package com.example.studentcenterapp.navigation
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavHostController
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.composable
+import androidx.navigation.compose.rememberNavController
+import com.example.studentcenterapp.ui.theme.StudentCenterAppTheme
+
+
+@Composable
+fun StudentCenterApp() {
+    StudentCenterAppTheme {
+        Surface(modifier = Modifier.fillMaxSize()) {
+            val navController = rememberNavController()
+            StudentCenterNavHost(navController)
+        }
+    }
+}
+
+@Composable
+fun StudentCenterNavHost(
+    navController: NavHostController
+) {
+    NavHost(
+        navController = navController,
+        startDestination = Screen.Splash.route
+    ) {
+        composable(Screen.Splash.route) {
+            PlaceholderScreen("Splash")
+        }
+        composable(Screen.Departments.route) {
+            PlaceholderScreen("Departments")
+        }
+        composable(Screen.Services.route) {
+            PlaceholderScreen("Services")
+        }
+        composable(Screen.Slots.route) {
+            PlaceholderScreen("Slots")
+        }
+        composable(Screen.Confirm.route) {
+            PlaceholderScreen("Confirm")
+        }
+        composable(Screen.Appointments.route) {
+            PlaceholderScreen("Appointments")
+        }
+        composable(Screen.StaffDashboard.route) {
+            PlaceholderScreen("Staff Dashboard")
+        }
+    }
+}
+
+@Composable
+private fun PlaceholderScreen(name: String) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(text = "TODO: $name screen")
+    }
+}
+@Preview(showBackground = true)
+@Composable
+fun StudentCenterAppPreview() {
+    StudentCenterApp()
+}


### PR DESCRIPTION
Summary

This pull request completes Issue 02 – Project Setup & Base Navigation.
The goal of this PR is to establish the initial project structure and implement the base navigation architecture for the StudentCenterApp.
 
📁 Project Structure

The following base packages were created under app/src/main/java/com/example/studentcenterapp:
- `model/`
- `data/`
  - `department/`
  - `service/`
  - `student/`
  - `staff/`
  - `timeslot/`
  - `appointment/`
  - `inmemory/`
- `viewmodel/`
- `ui/`
  - `splash/`
  - `department/`
  - `service/`
  - `staff/`
  - `timeslot/`
  - `appointment/`
  - `common/`
- `navigation/`
  - `Screen.kt`
  - `StudentCenterNavHost.kt`
  
This structure follows the planned Clean Architecture + MVVM + Repository pattern.
 
🚀 Navigation Setup

A functional NavHost has been implemented using Jetpack Navigation Compose.

Placeholder destinations have been added for all main flows:
- `Splash`
- `Departments`
- `Services`
- `Slots`
- `Confirm`
- `Appointments`
- `StaffDashboard`

This ensures that the full navigation graph compiles and provides a foundation for upcoming feature work.
 
🎨 Temporary UI
•	All screens currently display a simple PlaceholderScreen("ScreenName").
•	Real UI screens such as SplashScreen, DepartmentListScreen, and AppointmentDetailScreen will be implemented in upcoming issues.
•	This PR focuses only on the navigation graph and project structure, not on final UI.
 
