### PR TITLE
Department Repository & Models (Issue 5)

### DIFF
--- a/app/src/main/java/com/example/studentcenterapp/data/AppDI.kt
+++ b/app/src/main/java/com/example/studentcenterapp/data/AppDI.kt
@@ -1,0 +1,11 @@
+package com.example.studentcenterapp.data
+
+import com.example.studentcenterapp.data.department.DepartmentRepository
+import com.example.studentcenterapp.data.department.DepartmentRepositoryImpl
+import com.example.studentcenterapp.data.department.InMemoryDepartmentDataSource
+
+object AppDI {
+    val departmentRepository: DepartmentRepository by lazy {
+        DepartmentRepositoryImpl(InMemoryDepartmentDataSource())
+    }
+}

--- a/app/src/main/java/com/example/studentcenterapp/data/department/DepartmentDataSource.kt
+++ b/app/src/main/java/com/example/studentcenterapp/data/department/DepartmentDataSource.kt
@@ -1,0 +1,8 @@
+package com.example.studentcenterapp.data.department
+
+import com.example.studentcenterapp.model.Department
+import kotlinx.coroutines.flow.Flow
+
+interface DepartmentDataSource {
+    fun getDepartments(): Flow<List<Department>>
+}

--- a/app/src/main/java/com/example/studentcenterapp/data/department/DepartmentRepository.kt
+++ b/app/src/main/java/com/example/studentcenterapp/data/department/DepartmentRepository.kt
@@ -1,0 +1,8 @@
+package com.example.studentcenterapp.data.department
+
+import com.example.studentcenterapp.model.Department
+import kotlinx.coroutines.flow.Flow
+
+interface DepartmentRepository {
+    fun getDepartments(): Flow<List<Department>>
+}

--- a/app/src/main/java/com/example/studentcenterapp/data/department/DepartmentRepositoryImpl.kt
+++ b/app/src/main/java/com/example/studentcenterapp/data/department/DepartmentRepositoryImpl.kt
@@ -1,0 +1,13 @@
+package com.example.studentcenterapp.data.department
+
+import com.example.studentcenterapp.model.Department
+import kotlinx.coroutines.flow.Flow
+
+class DepartmentRepositoryImpl(
+    private val dataSource: DepartmentDataSource
+) : DepartmentRepository {
+
+    override fun getDepartments(): Flow<List<Department>> {
+        return dataSource.getDepartments()
+    }
+}

--- a/app/src/main/java/com/example/studentcenterapp/data/department/InMemoryDepartmentDataSource.kt
+++ b/app/src/main/java/com/example/studentcenterapp/data/department/InMemoryDepartmentDataSource.kt
@@ -1,0 +1,19 @@
+package com.example.studentcenterapp.data.department
+
+import com.example.studentcenterapp.model.Department
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+
+class InMemoryDepartmentDataSource : DepartmentDataSource {
+
+    private val departments = listOf(
+        Department(id = "dep1", name = "Bireysel ve Akademik Gelişim", description = "…"),
+        Department(id = "dep2", name = "Burs Yönetimi", description = "…"),
+        Department(id = "dep3", name = "Kariyer Gelişimi", description = "…"),
+        Department(id = "dep4", name = "Kültür Sanat", description = "…"),
+        Department(id = "dep5", name = "Mezunlarla İletişim", description = "…"),
+        Department(id = "dep6", name = "Psikolojik Danışmanlık ve Rehberlik", description = "…"),
+    )
+
+    override fun getDepartments(): Flow<List<Department>> = flowOf(departments)
+}

--- a/app/src/main/java/com/example/studentcenterapp/model/Department.kt
+++ b/app/src/main/java/com/example/studentcenterapp/model/Department.kt
@@ -4,5 +4,5 @@ data class Department(
     val id: String,
     val name: String,
     val description: String,
-    val location: String
+    val location: String = ""
 )


### PR DESCRIPTION
Summary

This pull request completes Issue 05 – DepartmentRepository and Department models.
The goal of this PR is to provide a clean and reusable data access layer for departments using the repository pattern and to define the core department model with a mock in-memory data source for the demo app.

⸻

Changes Included

🏢 Department model
	•	Defined Department data class under the model/ package
	•	Includes core fields required by the application flow (e.g. id, name, description, location)
	•	Designed to be shared safely across data, domain, and UI layers

⸻

🗄 Department data source
	•	Added DepartmentDataSource interface under data/department/

fun getDepartments(): Flow<List<Department>>


	•	Implemented an in-memory data source
	•	Provides a non-empty mock list of departments
	•	Uses Flow<List<Department>> for reactive data delivery
	•	Serves as a temporary stub until Room or backend integration

⸻

🧠 Department repository
	•	Defined DepartmentRepository interface
	•	Implemented DepartmentRepositoryImpl
	•	Delegates all data access to DepartmentDataSource
	•	Prevents direct UI-to-data source access
	•	Follows the same repository structure used in the Service data flow

⸻

Architecture Notes
	•	Repository pattern matches the existing ServiceRepository implementation
	•	Data layer is fully decoupled from UI components
	•	Flow-based API allows safe consumption from ViewModels
	•	Repository is ready to be injected into ViewModels when DI is introduced

⸻