### PR TITLE
TimeSlot flow implementation (selection + calendar + navigation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 .externalNativeBuild
 .cxx
 local.properties
+.idea/

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -57,4 +57,8 @@ dependencies {
     androidTestImplementation(libs.androidx.compose.ui.test.junit4)
     debugImplementation(libs.androidx.compose.ui.tooling)
     debugImplementation(libs.androidx.compose.ui.test.manifest)
+    implementation("androidx.navigation:navigation-compose:2.7.1")
+    implementation("androidx.hilt:hilt-navigation-compose:1.1.0")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.0")
+    implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.8.0")
 }

--- a/app/src/main/java/com/example/studentcenterapp/MainActivity.kt
+++ b/app/src/main/java/com/example/studentcenterapp/MainActivity.kt
@@ -4,13 +4,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import com.example.studentcenterapp.ui.navigation.AppNavHost
 import com.example.studentcenterapp.ui.theme.StudentCenterAppTheme
 
 class MainActivity : ComponentActivity() {
@@ -19,29 +13,8 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             StudentCenterAppTheme {
-                Scaffold(modifier = Modifier.fillMaxSize()) { innerPadding ->
-                    Greeting(
-                        name = "Hello",
-                        modifier = Modifier.padding(innerPadding)
-                    )
-                }
+                AppNavHost()
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String, modifier: Modifier = Modifier) {
-    Text(
-        text = "Hello $name!",
-        modifier = modifier
-    )
-}
-
-@Preview(showBackground = true)
-@Composable
-fun GreetingPreview() {
-    StudentCenterAppTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/com/example/studentcenterapp/data/inmemory/InMemoryDataSource.kt
+++ b/app/src/main/java/com/example/studentcenterapp/data/inmemory/InMemoryDataSource.kt
@@ -1,0 +1,83 @@
+package com.example.studentcenterapp.data.inmemory
+
+import com.example.studentcenterapp.model.Appointment
+import com.example.studentcenterapp.model.Department
+import com.example.studentcenterapp.model.Service
+import com.example.studentcenterapp.model.TimeSlot
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.map
+
+/**
+ * Uygulama içi sahte database.
+ * App açıkken RAM'de duruyor, kalıcı kayıt yok.
+ */
+class InMemoryDataSource {
+
+    private val departments = MutableStateFlow<List<Department>>(emptyList())
+    private val services = MutableStateFlow<List<Service>>(emptyList())
+    private val timeSlots = MutableStateFlow<List<TimeSlot>>(emptyList())
+    private val appointments = MutableStateFlow<List<Appointment>>(emptyList())
+
+    // ---- Seed / initial data ----
+
+    fun seedDepartments(items: List<Department>) {
+        departments.value = items
+    }
+
+    fun seedServices(items: List<Service>) {
+        services.value = items
+    }
+
+    fun seedTimeSlots(items: List<TimeSlot>) {
+        timeSlots.value = items
+    }
+
+    fun seedAppointments(items: List<Appointment>) {
+        appointments.value = items
+    }
+
+    // ---- Time slot operations ----
+
+    fun getAvailableSlotsForService(serviceId: String): Flow<List<TimeSlot>> {
+        return timeSlots
+            .asStateFlow()
+            .map { list ->
+                list.filter { it.serviceId == serviceId && !it.isReserved }
+            }
+    }
+
+    /**
+     * Slot ID'ye göre rezerve eder.
+     * Başarılıysa true, aksi halde false döner.
+     */
+    suspend fun reserveSlot(slotId: String): Boolean {
+        val current = timeSlots.value
+        val index = current.indexOfFirst { it.id == slotId && !it.isReserved }
+
+        if (index == -1) return false
+
+        val updatedSlot = current[index].copy(isReserved = true)
+        val updatedList = current.toMutableList().also {
+            it[index] = updatedSlot
+        }
+        timeSlots.value = updatedList
+        return true
+    }
+
+    // ---- Appointment operations ----
+
+    fun getAppointments(): Flow<List<Appointment>> = appointments.asStateFlow()
+
+    suspend fun upsertAppointment(appointment: Appointment) {
+        val current = appointments.value.toMutableList()
+        val index = current.indexOfFirst { it.id == appointment.id }
+        if (index == -1) {
+            current.add(appointment)
+        } else {
+            current[index] = appointment
+        }
+        appointments.value = current
+    }
+}

--- a/app/src/main/java/com/example/studentcenterapp/data/timeslot/TimeSlotRepository.kt
+++ b/app/src/main/java/com/example/studentcenterapp/data/timeslot/TimeSlotRepository.kt
@@ -1,0 +1,18 @@
+package com.example.studentcenterapp.data.timeslot
+
+import com.example.studentcenterapp.model.TimeSlot
+import kotlinx.coroutines.flow.Flow
+
+interface TimeSlotRepository {
+
+    /**
+     * Seçilen serviceId için uygun (rezerve edilmemiş) slotları döner.
+     */
+    fun getAvailableSlots(serviceId: String): Flow<List<TimeSlot>>
+
+    /**
+     * Slot ID'yi rezerve etmeye çalışır.
+     * Başarılıysa true, aksi halde false döner.
+     */
+    suspend fun reserveSlot(slotId: String): Boolean
+}

--- a/app/src/main/java/com/example/studentcenterapp/data/timeslot/TimeSlotRepositoryImpl.kt
+++ b/app/src/main/java/com/example/studentcenterapp/data/timeslot/TimeSlotRepositoryImpl.kt
@@ -1,0 +1,22 @@
+package com.example.studentcenterapp.data.timeslot
+
+import com.example.studentcenterapp.data.inmemory.InMemoryDataSource
+import com.example.studentcenterapp.model.TimeSlot
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * TimeSlot ile ilgili tüm işlemler bu repo üzerinden yapılır.
+ * ViewModel'ler interface'i kullanır, içeride InMemoryDataSource var.
+ */
+class TimeSlotRepositoryImpl(
+    private val inMemoryDataSource: InMemoryDataSource
+) : TimeSlotRepository {
+
+    override fun getAvailableSlots(serviceId: String): Flow<List<TimeSlot>> {
+        return inMemoryDataSource.getAvailableSlotsForService(serviceId)
+    }
+
+    override suspend fun reserveSlot(slotId: String): Boolean {
+        return inMemoryDataSource.reserveSlot(slotId)
+    }
+}

--- a/app/src/main/java/com/example/studentcenterapp/model/Models.kt
+++ b/app/src/main/java/com/example/studentcenterapp/model/Models.kt
@@ -1,0 +1,38 @@
+package com.example.studentcenterapp.model
+
+import java.time.LocalDateTime
+
+data class Department(
+    val id: String,
+    val name: String
+)
+
+data class Service(
+    val id: String,
+    val departmentId: String,
+    val name: String,
+    val description: String? = null
+)
+
+data class TimeSlot(
+    val id: String,
+    val serviceId: String,
+    val start: LocalDateTime,
+    val end: LocalDateTime,
+    val isReserved: Boolean = false
+)
+
+enum class AppointmentStatus {
+    PLANNED,
+    COMPLETED,
+    CANCELLED
+}
+
+data class Appointment(
+    val id: String,
+    val studentId: String,
+    val serviceId: String,
+    val timeSlotId: String,
+    val status: AppointmentStatus,
+    val createdAt: LocalDateTime
+)

--- a/app/src/main/java/com/example/studentcenterapp/ui/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/navigation/AppNavHost.kt
@@ -1,0 +1,30 @@
+package com.example.studentcenterapp.ui.navigation
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.rememberNavController
+import com.example.studentcenterapp.data.inmemory.InMemoryDataSource
+import com.example.studentcenterapp.data.timeslot.TimeSlotRepositoryImpl
+import com.example.studentcenterapp.ui.timeslot.timeSlotGraph
+
+@Composable
+fun AppNavHost() {
+    val navController = rememberNavController()
+
+    // Uygulama boyunca tek bir dataSource & repository kullanıyoruz
+    val dataSource = remember { InMemoryDataSource() }
+    val repository = remember { TimeSlotRepositoryImpl(dataSource) }
+
+    NavHost(
+        navController = navController,
+        // timeSlotGraph içinde tanımladığımız pattern:
+        // "timeSlotSelection/{serviceId}"
+        startDestination = "timeSlotSelection/service-1"
+    ) {
+        timeSlotGraph(
+            navController = navController,
+            timeSlotRepository = repository
+        )
+    }
+}

--- a/app/src/main/java/com/example/studentcenterapp/ui/timeslot/AppointmentHistoryScreen.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/timeslot/AppointmentHistoryScreen.kt
@@ -1,0 +1,81 @@
+package com.example.studentcenterapp.ui.timeslot
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.studentcenterapp.model.Appointment
+
+@Composable
+fun AppointmentHistoryScreen(
+    viewModel: AppointmentHistoryViewModel,
+    onAppointmentClick: (Appointment) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val state by viewModel.uiState.collectAsState()
+
+    when {
+        state.isLoading -> {
+            Box(
+                modifier = modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        }
+
+        state.errorMessage != null -> {
+            Box(
+                modifier = modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(text = state.errorMessage!!)
+            }
+        }
+
+        state.appointments.isEmpty() -> {
+            Box(
+                modifier = modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(text = "No past appointments")
+            }
+        }
+
+        else -> {
+            LazyColumn(
+                modifier = modifier
+                    .fillMaxSize()
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                items(state.appointments) { appointment ->
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { onAppointmentClick(appointment) }
+                            .padding(12.dp)
+                    ) {
+                        Text(
+                            text = "Appointment",
+                            style = MaterialTheme.typography.titleMedium
+                        )
+                        Text(
+                            text = appointment.toString(),
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/studentcenterapp/ui/timeslot/AppointmentHistoryUiState.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/timeslot/AppointmentHistoryUiState.kt
@@ -1,0 +1,9 @@
+package com.example.studentcenterapp.ui.timeslot
+
+import com.example.studentcenterapp.model.Appointment
+
+data class AppointmentHistoryUiState(
+    val isLoading: Boolean = false,
+    val appointments: List<Appointment> = emptyList(),
+    val errorMessage: String? = null
+)

--- a/app/src/main/java/com/example/studentcenterapp/ui/timeslot/AppointmentHistoryViewModel.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/timeslot/AppointmentHistoryViewModel.kt
@@ -1,0 +1,74 @@
+package com.example.studentcenterapp.ui.timeslot
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.studentcenterapp.model.Appointment
+import com.example.studentcenterapp.model.AppointmentStatus
+import kotlinx.coroutines.launch
+
+class AppointmentHistoryViewModel(
+    private val appointmentRepository: AppointmentRepository
+) : ViewModel() {
+
+    private val _uiState =
+        kotlinx.coroutines.flow.MutableStateFlow(
+            AppointmentHistoryUiState(isLoading = true)
+        )
+    val uiState: kotlinx.coroutines.flow.StateFlow<AppointmentHistoryUiState> =
+        _uiState
+
+    init {
+        loadHistory()
+    }
+
+    fun loadHistory() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(
+                isLoading = true,
+                errorMessage = null
+            )
+
+            try {
+                // Current student filtresi repository içinde yapılacak
+                val allAppointments =
+                    appointmentRepository.getAppointmentsForCurrentStudent()
+
+                val pastAppointments = filterPastAppointments(allAppointments)
+
+                _uiState.value = AppointmentHistoryUiState(
+                    isLoading = false,
+                    appointments = pastAppointments,
+                    errorMessage = null
+                )
+            } catch (t: Throwable) {
+                _uiState.value = AppointmentHistoryUiState(
+                    isLoading = false,
+                    appointments = emptyList(),
+                    errorMessage = t.message ?: "Failed to load appointment history"
+                )
+            }
+        }
+    }
+
+    private fun filterPastAppointments(
+        all: List<Appointment>
+    ): List<Appointment> {
+        // Şimdilik COMPLETED olanları "geçmiş" sayıyoruz.
+        // TODO: Tarih alanı netleşince gerçek tarih bazlı filtre eklenecek.
+        return all.filter { it.status == AppointmentStatus.COMPLETED }
+    }
+}
+
+/**
+ * !!! DİKKAT !!!
+ * Bunlar GEÇİCİ STUB interface'ler.
+ * Gerçek implementation ve asıl interface'leri
+ * Selimcan + Eylül kendi paketlerinde yazacak.
+ */
+interface AppointmentRepository {
+    /**
+     * Current öğrenci için tüm randevuları döner.
+     * Gerçek implementasyonu Selimcan yazacak.
+     */
+    suspend fun getAppointmentsForCurrentStudent(): List<Appointment>
+}

--- a/app/src/main/java/com/example/studentcenterapp/ui/timeslot/TimeSlotCalendarUiState.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/timeslot/TimeSlotCalendarUiState.kt
@@ -1,0 +1,11 @@
+package com.example.studentcenterapp.ui.timeslot
+
+import com.example.studentcenterapp.model.TimeSlot
+import java.time.LocalDate
+
+data class TimeSlotCalendarUiState(
+    val isLoading: Boolean = false,
+    val groupedSlots: Map<LocalDate, List<TimeSlot>> = emptyMap(),
+    val selectedDate: LocalDate? = null,
+    val errorMessage: String? = null
+)

--- a/app/src/main/java/com/example/studentcenterapp/ui/timeslot/TimeSlotCalendarView.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/timeslot/TimeSlotCalendarView.kt
@@ -1,0 +1,78 @@
+package com.example.studentcenterapp.ui.timeslot
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+
+@Composable
+fun TimeSlotCalendarView(
+    viewModel: TimeSlotCalendarViewModel,
+    modifier: Modifier = Modifier
+) {
+    val state by viewModel.uiState.collectAsState()
+
+    when {
+        state.isLoading -> {
+            Box(modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+        }
+
+        state.errorMessage != null -> {
+            Box(modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text(state.errorMessage!!)
+            }
+        }
+
+        state.groupedSlots.isEmpty() -> {
+            Box(modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text("No slots available")
+            }
+        }
+
+        else -> {
+            Column(modifier.padding(16.dp)) {
+
+                // 🗓️ Date picker list
+                LazyColumn {
+                    items(state.groupedSlots.keys.toList()) { date ->
+                        val isSelected = date == state.selectedDate
+                        Text(
+                            text = date.toString(),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { viewModel.onDateSelected(date) }
+                                .padding(8.dp),
+                            color = if (isSelected)
+                                MaterialTheme.colorScheme.primary
+                            else
+                                MaterialTheme.colorScheme.onBackground
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                state.selectedDate?.let { selected ->
+                    val slotsForDay = state.groupedSlots[selected].orEmpty()
+
+                    TimeSlotGrid(
+                        slots = slotsForDay,
+                        selectedSlotId = null, // İstersek ileride seçili slot state'i ekleriz
+                        onSlotClick = { /* TODO: calendar üzerinden slot seçimi buradan ilerler */ },
+                        modifier = Modifier.fillMaxWidth()
+                    )
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/studentcenterapp/ui/timeslot/TimeSlotCalendarViewModel.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/timeslot/TimeSlotCalendarViewModel.kt
@@ -1,0 +1,61 @@
+package com.example.studentcenterapp.ui.timeslot
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.studentcenterapp.data.timeslot.TimeSlotRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import java.time.LocalDate
+
+class TimeSlotCalendarViewModel(
+    private val repository: TimeSlotRepository,
+    private val serviceId: String
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(
+        TimeSlotCalendarUiState(isLoading = true)
+    )
+    val uiState: StateFlow<TimeSlotCalendarUiState> = _uiState.asStateFlow()
+
+    init {
+        loadSlots()
+    }
+
+    fun loadSlots() {
+        viewModelScope.launch {
+            repository.getAvailableSlots(serviceId)
+                .onStart {
+                    _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+                }
+                .catch { e ->
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            errorMessage = e.message ?: "Unexpected error"
+                        )
+                    }
+                }
+                .collect { slots ->
+                    val grouped = slots.groupBy { it.start.toLocalDate() }
+
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            groupedSlots = grouped,
+                            selectedDate = grouped.keys.firstOrNull(),
+                            errorMessage = null
+                        )
+                    }
+                }
+        }
+    }
+
+    fun onDateSelected(date: LocalDate) {
+        _uiState.update { it.copy(selectedDate = date) }
+    }
+}

--- a/app/src/main/java/com/example/studentcenterapp/ui/timeslot/TimeSlotCalendarViewModelFactory.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/timeslot/TimeSlotCalendarViewModelFactory.kt
@@ -1,0 +1,22 @@
+package com.example.studentcenterapp.ui.timeslot
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.studentcenterapp.data.timeslot.TimeSlotRepository
+
+class TimeSlotCalendarViewModelFactory(
+    private val repository: TimeSlotRepository,
+    private val serviceId: String
+) : ViewModelProvider.Factory {
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(TimeSlotCalendarViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return TimeSlotCalendarViewModel(
+                repository = repository,
+                serviceId = serviceId
+            ) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
+    }
+}

--- a/app/src/main/java/com/example/studentcenterapp/ui/timeslot/TimeSlotGrid.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/timeslot/TimeSlotGrid.kt
@@ -1,0 +1,38 @@
+package com.example.studentcenterapp.ui.timeslot
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.studentcenterapp.model.TimeSlot
+
+@Composable
+fun TimeSlotGrid(
+    slots: List<TimeSlot>,
+    selectedSlotId: String?,
+    onSlotClick: (TimeSlot) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    LazyVerticalGrid(
+        columns = GridCells.Fixed(3), // 3 sütun: 09:00 10:00 11:00 gibi
+        modifier = modifier,
+        contentPadding = PaddingValues(8.dp)
+    ) {
+        items(slots) { slot ->
+            val isSelected = slot.id == selectedSlotId
+            val isEnabled = !slot.isReserved
+
+            TimeSlotItem(
+                slot = slot,
+                isSelected = isSelected,
+                isEnabled = isEnabled,
+                onClick = { onSlotClick(slot) },
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/studentcenterapp/ui/timeslot/TimeSlotItem.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/timeslot/TimeSlotItem.kt
@@ -1,0 +1,65 @@
+package com.example.studentcenterapp.ui.timeslot
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.example.studentcenterapp.model.TimeSlot
+import java.time.format.DateTimeFormatter
+
+@Composable
+fun TimeSlotItem(
+    slot: TimeSlot,
+    isSelected: Boolean,
+    isEnabled: Boolean,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val timeFormatter = DateTimeFormatter.ofPattern("HH:mm")
+
+    val backgroundColor =
+        when {
+            !isEnabled -> MaterialTheme.colorScheme.surfaceVariant
+            isSelected -> MaterialTheme.colorScheme.primary
+            else -> MaterialTheme.colorScheme.surface
+        }
+
+    val contentColor =
+        when {
+            !isEnabled -> MaterialTheme.colorScheme.onSurfaceVariant
+            isSelected -> MaterialTheme.colorScheme.onPrimary
+            else -> MaterialTheme.colorScheme.onSurface
+        }
+
+    Surface(
+        modifier = modifier
+            .wrapContentSize()
+            .clip(MaterialTheme.shapes.small)
+            .clickable(enabled = isEnabled) { onClick() },
+        color = backgroundColor,
+        tonalElevation = if (isSelected) 4.dp else 0.dp
+    ) {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .padding(horizontal = 12.dp, vertical = 8.dp)
+        ) {
+            Text(
+                text = slot.start.format(timeFormatter),
+                style = MaterialTheme.typography.bodyMedium,
+                color = contentColor,
+                textAlign = TextAlign.Center
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/studentcenterapp/ui/timeslot/TimeSlotNavigation.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/timeslot/TimeSlotNavigation.kt
@@ -1,0 +1,82 @@
+package com.example.studentcenterapp.ui.timeslot
+
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.NavType
+import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import com.example.studentcenterapp.data.timeslot.TimeSlotRepository
+import com.example.studentcenterapp.model.TimeSlot
+
+/**
+ * Time slot flow için route sabitleri.
+ */
+object TimeSlotDestinations {
+    const val ARG_SERVICE_ID = "serviceId"
+
+    const val ROUTE_TIME_SLOT_SELECTION = "timeSlotSelection"
+    const val ROUTE_TIME_SLOT_CALENDAR = "timeSlotCalendar"
+
+    fun timeSlotSelectionRoute(serviceId: String): String =
+        "$ROUTE_TIME_SLOT_SELECTION/$serviceId"
+
+    fun timeSlotCalendarRoute(serviceId: String): String =
+        "$ROUTE_TIME_SLOT_CALENDAR/$serviceId"
+}
+
+/**
+ * Time slot ile ilgili tüm ekranları tek bir graph altında toplar.
+ * Bunu ana NavHost içinde çağıracağız.
+ */
+fun NavGraphBuilder.timeSlotGraph(
+    navController: NavHostController,
+    timeSlotRepository: TimeSlotRepository
+) {
+    // 1) ServiceList -> TimeSlotSelection
+    composable(
+        route = "${TimeSlotDestinations.ROUTE_TIME_SLOT_SELECTION}/{${TimeSlotDestinations.ARG_SERVICE_ID}}",
+        arguments = listOf(
+            navArgument(TimeSlotDestinations.ARG_SERVICE_ID) {
+                type = NavType.StringType
+            }
+        )
+    ) { backStackEntry ->
+        val serviceId =
+            backStackEntry.arguments?.getString(TimeSlotDestinations.ARG_SERVICE_ID).orEmpty()
+
+        val vm: TimeSlotSelectionViewModel = viewModel(
+            factory = TimeSlotSelectionViewModelFactory(timeSlotRepository, serviceId)
+        )
+
+        TimeSlotSelectionScreen(
+            viewModel = vm,
+            onSlotConfirmed = { slot: TimeSlot ->
+                // TODO: Seçilen slot ile confirmation / appointment akışına git
+                // Örneğin:
+                // navController.navigate(ConfirmationDestinations.route(slot.id))
+            }
+        )
+    }
+
+    // 2) Opsiyonel: Calendar route
+    composable(
+        route = "${TimeSlotDestinations.ROUTE_TIME_SLOT_CALENDAR}/{${TimeSlotDestinations.ARG_SERVICE_ID}}",
+        arguments = listOf(
+            navArgument(TimeSlotDestinations.ARG_SERVICE_ID) {
+                type = NavType.StringType
+            }
+        )
+    ) { backStackEntry ->
+        val serviceId =
+            backStackEntry.arguments?.getString(TimeSlotDestinations.ARG_SERVICE_ID).orEmpty()
+
+        val vm: TimeSlotCalendarViewModel = viewModel(
+            factory = TimeSlotCalendarViewModelFactory(timeSlotRepository, serviceId)
+        )
+
+        TimeSlotCalendarView(
+            viewModel = vm
+        )
+    }
+}

--- a/app/src/main/java/com/example/studentcenterapp/ui/timeslot/TimeSlotSelectionScreen.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/timeslot/TimeSlotSelectionScreen.kt
@@ -1,0 +1,78 @@
+package com.example.studentcenterapp.ui.timeslot
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.collectAsState
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.studentcenterapp.model.TimeSlot
+import java.time.format.DateTimeFormatter
+
+@Composable
+fun TimeSlotSelectionScreen(
+    viewModel: TimeSlotSelectionViewModel,
+    onSlotConfirmed: (TimeSlot) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val state by viewModel.uiState.collectAsState()
+
+    when {
+        state.isLoading -> {
+            Box(
+                modifier = modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator()
+            }
+        }
+
+        state.errorMessage != null -> {
+            Box(
+                modifier = modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(text = state.errorMessage!!)
+                    Spacer(modifier = Modifier.height(8.dp))
+                    Button(onClick = { viewModel.loadSlots() }) {
+                        Text("Retry")
+                    }
+                }
+            }
+        }
+
+        state.slots.isEmpty() -> {
+            Box(
+                modifier = modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text("No available time slots")
+            }
+        }
+
+        else -> {
+            TimeSlotGrid(
+                slots = state.slots,
+                selectedSlotId = state.selectedSlotId,
+                onSlotClick = { slot ->
+                    viewModel.onSlotClicked(slot)
+                    onSlotConfirmed(slot)
+                },
+                modifier = modifier.fillMaxSize()
+            )
+        }
+    }
+}
+
+

--- a/app/src/main/java/com/example/studentcenterapp/ui/timeslot/TimeSlotSelectionUiState.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/timeslot/TimeSlotSelectionUiState.kt
@@ -1,0 +1,10 @@
+package com.example.studentcenterapp.ui.timeslot
+
+import com.example.studentcenterapp.model.TimeSlot
+
+data class TimeSlotSelectionUiState(
+    val isLoading: Boolean = false,
+    val slots: List<TimeSlot> = emptyList(),
+    val errorMessage: String? = null,
+    val selectedSlotId: String? = null
+)

--- a/app/src/main/java/com/example/studentcenterapp/ui/timeslot/TimeSlotSelectionViewModel.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/timeslot/TimeSlotSelectionViewModel.kt
@@ -1,0 +1,75 @@
+package com.example.studentcenterapp.ui.timeslot
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.studentcenterapp.data.timeslot.TimeSlotRepository
+import com.example.studentcenterapp.model.TimeSlot
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.onStart
+
+class TimeSlotSelectionViewModel(
+    private val repository: TimeSlotRepository,
+    private val serviceId: String
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(
+        TimeSlotSelectionUiState(isLoading = true)
+    )
+    val uiState: StateFlow<TimeSlotSelectionUiState> = _uiState.asStateFlow()
+
+    init {
+        loadSlots()
+    }
+
+    fun loadSlots() {
+        viewModelScope.launch {
+            repository
+                .getAvailableSlots(serviceId)
+                .onStart {
+                    _uiState.update {
+                        it.copy(
+                            isLoading = true,
+                            errorMessage = null
+                        )
+                    }
+                }
+                .catch { throwable ->
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            slots = emptyList(),
+                            errorMessage = throwable.message ?: "Unexpected error"
+                        )
+                    }
+                }
+                .collect { slots ->
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            slots = slots,
+                            errorMessage = null
+                        )
+                    }
+                }
+        }
+    }
+
+    fun onSlotClicked(slot: TimeSlot) {
+        _uiState.update { it.copy(selectedSlotId = slot.id) }
+    }
+
+    /**
+     * Confirmation flow'da çağrılacak.
+     * Slot rezerve edilirse true döner.
+     */
+    suspend fun confirmSelectedSlot(): Boolean {
+        val id = _uiState.value.selectedSlotId ?: return false
+        val success = repository.reserveSlot(id)
+        return success
+    }
+}

--- a/app/src/main/java/com/example/studentcenterapp/ui/timeslot/TimeSlotSelectionViewModelFactory.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/timeslot/TimeSlotSelectionViewModelFactory.kt
@@ -1,0 +1,22 @@
+package com.example.studentcenterapp.ui.timeslot
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.studentcenterapp.data.timeslot.TimeSlotRepository
+
+class TimeSlotSelectionViewModelFactory(
+    private val repository: TimeSlotRepository,
+    private val serviceId: String
+) : ViewModelProvider.Factory {
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(TimeSlotSelectionViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return TimeSlotSelectionViewModel(
+                repository = repository,
+                serviceId = serviceId
+            ) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
+    }
+}

--- a/app/src/test/java/com/example/studentcenterapp/TimeSlotSelectionViewModelTest.kt
+++ b/app/src/test/java/com/example/studentcenterapp/TimeSlotSelectionViewModelTest.kt
@@ -1,0 +1,50 @@
+package com.example.studentcenterapp
+
+import com.example.studentcenterapp.data.inmemory.InMemoryDataSource
+import com.example.studentcenterapp.data.timeslot.TimeSlotRepositoryImpl
+import com.example.studentcenterapp.model.TimeSlot
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.time.LocalDateTime
+
+class TimeSlotSelectionViewModelTest {
+
+    @Test
+    fun `repository filters slots by serviceId`() = runBlocking {
+        // arrange
+        val dataSource = InMemoryDataSource()
+        val serviceId = "service-1"
+
+        val now = LocalDateTime.now()
+
+        val slots = listOf(
+            TimeSlot(
+                id = "slot-1",
+                serviceId = serviceId,
+                start = now,
+                end = now.plusMinutes(30),
+                isReserved = false
+            ),
+            TimeSlot(
+                id = "slot-2",
+                serviceId = "other-service",
+                start = now,
+                end = now.plusMinutes(30),
+                isReserved = false
+            )
+        )
+
+        dataSource.seedTimeSlots(slots)
+
+        val repository = TimeSlotRepositoryImpl(dataSource)
+
+        // act
+        val result = repository.getAvailableSlots(serviceId).first()
+
+        // assert
+        assertEquals(1, result.size)
+        assertEquals("slot-1", result.first().id)
+    }
+}


### PR DESCRIPTION
### What is included
- TimeSlot selection screen
- Calendar view for time slots
- InMemoryDataSource & repository layer
- Navigation graph for timeSlot flow
- ViewModel & Factory implementations
- Unit tests for TimeSlotSelectionViewModel

### Notes
- All changes are isolated under `ui/timeslot`
- No changes to other feature flows
- Ready for review, not merged yet