### PR TITLE
Implement StaffDashboardScreen and StaffDashboardViewModel (Closes #15)

### DIFF
--- a/app/src/main/java/com/example/studentcenterapp/navigation/StudentCenterNavHost.kt
+++ b/app/src/main/java/com/example/studentcenterapp/navigation/StudentCenterNavHost.kt
@@ -1,5 +1,8 @@
 package com.example.studentcenterapp.navigation
 
+import com.example.studentcenterapp.ui.staff.StaffDashboardScreen
+import com.example.studentcenterapp.ui.staff.StaffDashboardViewModel
+import com.example.studentcenterapp.ui.staff.StaffDashboardViewModelFactory
 import androidx.compose.runtime.LaunchedEffect
 import com.example.studentcenterapp.ui.service.ServiceListScreen
 import com.example.studentcenterapp.ui.service.ServiceListViewModel
@@ -64,7 +67,7 @@ fun StudentCenterNavHost(
                 onStudentClick = { navController.navigate(Screen.Departments.route)
                 },
                 onStaffClick = {
-                    // TODO: ileride Staff login
+                    navController.navigate("staffDashboard/staff1")
                 }
             )
         }
@@ -118,6 +121,32 @@ fun StudentCenterNavHost(
                 }
             )
         }
+
+        composable("staffDashboard/{staffId}") { backStackEntry ->
+            val staffId = backStackEntry.arguments?.getString("staffId").orEmpty()
+
+            val vm: StaffDashboardViewModel = viewModel(
+                factory = StaffDashboardViewModelFactory(staffId, AppDI.staffRepository)
+            )
+
+            val state by vm.uiState.collectAsState()
+            val actionLoading by vm.actionLoading.collectAsState()
+            val actionError by vm.actionError.collectAsState()
+
+            StaffDashboardScreen(
+                state = state,
+                actionLoading = actionLoading,
+                actionError = actionError,
+                currentRoute = Screen.StaffDashboard.route,
+                onTabSelected = { tab ->
+                    navController.navigate(tab.route) { launchSingleTop = true }
+                },
+                onApprove = { vm.approve(it) },
+                onReject = { vm.reject(it) }
+            )
+
+        }
+
 
 
         composable(Screen.Services.route) {

--- a/app/src/main/java/com/example/studentcenterapp/ui/staff/StaffDashboardFilters.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/staff/StaffDashboardFilters.kt
@@ -1,0 +1,79 @@
+package com.example.studentcenterapp.ui.staff
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+enum class StaffAppointmentFilter(val label: String) {
+    ACTIVE("Aktif\nRandevular"),
+    PENDING("Onay\nBekliyor"),
+    CANCELLED("İptal Edilen\nRandevular"),
+    ALL("Tüm\nRandevular")
+}
+
+@Composable
+fun StaffFilterRow(
+    selected: StaffAppointmentFilter,
+    onSelect: (StaffAppointmentFilter) -> Unit
+) {
+    Row(
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        modifier = Modifier.padding(top = 12.dp, bottom = 10.dp)
+    ) {
+        StaffFilterChip(
+            text = StaffAppointmentFilter.ACTIVE.label,
+            selected = selected == StaffAppointmentFilter.ACTIVE,
+            onClick = { onSelect(StaffAppointmentFilter.ACTIVE) }
+        )
+        StaffFilterChip(
+            text = StaffAppointmentFilter.PENDING.label,
+            selected = selected == StaffAppointmentFilter.PENDING,
+            onClick = { onSelect(StaffAppointmentFilter.PENDING) }
+        )
+        StaffFilterChip(
+            text = StaffAppointmentFilter.CANCELLED.label,
+            selected = selected == StaffAppointmentFilter.CANCELLED,
+            onClick = { onSelect(StaffAppointmentFilter.CANCELLED) }
+        )
+        StaffFilterChip(
+            text = StaffAppointmentFilter.ALL.label,
+            selected = selected == StaffAppointmentFilter.ALL,
+            onClick = { onSelect(StaffAppointmentFilter.ALL) }
+        )
+    }
+}
+
+@Composable
+private fun StaffFilterChip(
+    text: String,
+    selected: Boolean,
+    onClick: () -> Unit
+) {
+    val container = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surface
+    val content = if (selected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.primary
+
+    Surface(
+        modifier = Modifier
+            .widthIn(min = 72.dp)
+            .clickable(onClick = onClick),
+        shape = MaterialTheme.shapes.small,
+        color = container,
+        contentColor = content,
+        border = if (selected) null else BorderStroke(1.dp, MaterialTheme.colorScheme.primary)
+    ) {
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelMedium,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/example/studentcenterapp/ui/staff/StaffDashboardScreen.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/staff/StaffDashboardScreen.kt
@@ -1,0 +1,266 @@
+package com.example.studentcenterapp.ui.staff
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
+import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.example.studentcenterapp.model.Appointment
+import com.example.studentcenterapp.ui.common.*
+import com.example.studentcenterapp.ui.state.UiState
+import com.example.studentcenterapp.ui.theme.PrimaryBlue
+
+private val GrayPanel = Color(0xFFE9E9E9)     // büyük gri zemin
+private val GrayCard  = Color(0xFFDADADA)     // list item kart gri
+private val ChipBlue  = Color(0xFF2EA7D8)     // sekme outline
+private val ChipFill  = Color(0xFFDFF3FB)     // seçili sekme dolu (açık mavi)
+
+private enum class StaffTab { ACTIVE, PENDING, CANCELLED, ALL }
+
+@Composable
+fun StaffDashboardScreen(
+    state: UiState<List<Appointment>>,
+    actionLoading: Boolean,
+    actionError: String?,
+    currentRoute: String?,
+    onTabSelected: (AppTab) -> Unit,
+    onApprove: (appointmentId: String) -> Unit,
+    onReject: (appointmentId: String) -> Unit
+) {
+    var selected by remember { mutableStateOf(StaffTab.PENDING) }
+
+    Scaffold(
+        topBar = { AppTopBar(title = "") },
+        bottomBar = {
+            AppBottomBar(
+                tabs = bottomTabs,
+                currentRoute = currentRoute,
+                onTabSelected = onTabSelected
+            )
+        },
+        containerColor = PrimaryBlue
+    ) { padding ->
+        ContentCard(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(padding)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 18.dp, vertical = 16.dp)
+            ) {
+                // Header row (Merhaba + sağda avatar gri)
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text("Merhaba, Elif.", style = MaterialTheme.typography.titleLarge)
+                    Spacer(Modifier.weight(1f))
+                    Box(
+                        Modifier
+                            .size(36.dp)
+                            .background(Color(0xFFD0D0D0), CircleShape)
+                    )
+                }
+
+                // Büyük gri panel (sekme + tarih + liste)
+                Surface(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 14.dp),
+                    shape = RoundedCornerShape(18.dp),
+                    color = GrayPanel
+                ) {
+                    Column(Modifier.padding(12.dp)) {
+
+                        // 4'lü kutular (outline + seçili dolu)
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.spacedBy(10.dp)
+                        ) {
+                            SegBox("Aktif\nRandevular", selected == StaffTab.ACTIVE) { selected = StaffTab.ACTIVE }
+                            SegBox("Onay\nBekliyor", selected == StaffTab.PENDING, badge = true) { selected = StaffTab.PENDING }
+                            SegBox("İptal Edilen\nRandevular", selected == StaffTab.CANCELLED) { selected = StaffTab.CANCELLED }
+                            SegBox("Tüm\nRandevular", selected == StaffTab.ALL) { selected = StaffTab.ALL }
+                        }
+
+                        // Tarih satırı
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(top = 10.dp, bottom = 10.dp),
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            IconButton(onClick = { /* prev day */ }) {
+                                Icon(Icons.AutoMirrored.Filled.KeyboardArrowLeft, contentDescription = "Prev")
+                            }
+                            Spacer(Modifier.weight(1f))
+                            Text("27 Ekim, Pazartesi", style = MaterialTheme.typography.titleMedium)
+                            Spacer(Modifier.weight(1f))
+                            IconButton(onClick = { /* next day */ }) {
+                                Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = "Next")
+                            }
+                        }
+
+                        if (!actionError.isNullOrBlank()) {
+                            Text(
+                                text = actionError,
+                                color = MaterialTheme.colorScheme.error,
+                                modifier = Modifier.padding(bottom = 8.dp)
+                            )
+                        }
+
+                        when (state) {
+                            is UiState.Loading -> {
+                                Box(Modifier.fillMaxWidth().padding(vertical = 30.dp), contentAlignment = Alignment.Center) {
+                                    CircularProgressIndicator()
+                                }
+                            }
+                            is UiState.Error -> {
+                                Text(state.message, modifier = Modifier.padding(12.dp))
+                            }
+                            is UiState.Success -> {
+                                val all = state.data
+
+                                val filtered = when (selected) {
+                                    StaffTab.PENDING -> all.filter { it.status == "pending" }
+                                    StaffTab.ACTIVE -> all.filter { it.status == "approved" }
+                                    StaffTab.CANCELLED -> all.filter { it.status == "cancelled" }
+                                    StaffTab.ALL -> all
+                                }
+
+                                LazyColumn(
+                                    verticalArrangement = Arrangement.spacedBy(12.dp),
+                                    modifier = Modifier.fillMaxWidth()
+                                ) {
+                                    items(filtered, key = { it.id }) { appt ->
+                                        StaffAppointmentCard(
+                                            name = appt.studentId,     // şimdilik studentId gösteriyoruz
+                                            time = appt.timeSlotId,    // şimdilik timeSlotId gösteriyoruz
+                                            status = appt.status,
+                                            actionLoading = actionLoading,
+                                            showActions = (selected == StaffTab.PENDING),
+                                            onApprove = { onApprove(appt.id) },
+                                            onReject = { onReject(appt.id) }
+                                        )
+                                    }
+                                    item { Spacer(Modifier.height(8.dp)) }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SegBox(
+    text: String,
+    selected: Boolean,
+    badge: Boolean = false,
+    onClick: () -> Unit
+) {
+    Box {
+        Surface(
+            modifier = Modifier
+                .width(86.dp)
+                .height(46.dp)
+                .clickable(onClick = onClick),
+            shape = RoundedCornerShape(12.dp),
+            color = if (selected) ChipFill else Color.Transparent,
+            border = BorderStroke(1.dp, ChipBlue)
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Text(text = text, style = MaterialTheme.typography.labelSmall, color = ChipBlue, lineHeight = MaterialTheme.typography.labelSmall.lineHeight)
+            }
+        }
+
+        if (badge) {
+            Box(
+                modifier = Modifier
+                    .size(16.dp)
+                    .align(Alignment.TopEnd)
+                    .offset(x = 6.dp, y = (-6).dp)
+                    .background(Color(0xFFE53935), CircleShape),
+                contentAlignment = Alignment.Center
+            ) {
+                Text("4", color = Color.White, style = MaterialTheme.typography.labelSmall)
+            }
+        }
+    }
+}
+
+@Composable
+private fun StaffAppointmentCard(
+    name: String,
+    time: String,
+    status: String,
+    actionLoading: Boolean,
+    showActions: Boolean,
+    onApprove: () -> Unit,
+    onReject: () -> Unit
+) {
+    Surface(
+        modifier = Modifier.fillMaxWidth(),
+        shape = RoundedCornerShape(16.dp),
+        color = GrayCard
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            // sol avatar
+            Box(Modifier.size(38.dp).background(Color(0xFFBDBDBD), CircleShape))
+            Spacer(Modifier.width(10.dp))
+
+            Column(Modifier.weight(1f)) {
+                Text(name, style = MaterialTheme.typography.titleMedium)
+                Text(time, style = MaterialTheme.typography.bodySmall, color = Color(0xFF6A6A6A))
+            }
+
+            StatusPill(status)
+
+            Spacer(Modifier.width(8.dp))
+            Icon(Icons.Filled.KeyboardArrowDown, contentDescription = "Expand")
+        }
+    }
+}
+
+@Composable
+private fun StatusPill(status: String) {
+    val (label, color) = when (status) {
+        "pending" -> "Onay" to Color(0xFF2EA7D8)
+        "approved" -> "Aktif" to Color(0xFF19B39A)
+        "cancelled" -> "İptal" to Color(0xFFE53935)
+        else -> status to Color(0xFF2EA7D8)
+    }
+
+    Surface(
+        shape = RoundedCornerShape(50),
+        color = Color.Transparent,
+        border = BorderStroke(1.dp, color)
+    ) {
+        Text(
+            text = label,
+            color = color,
+            style = MaterialTheme.typography.labelMedium,
+            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/example/studentcenterapp/ui/staff/StaffDashboardViewModel.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/staff/StaffDashboardViewModel.kt
@@ -1,0 +1,64 @@
+package com.example.studentcenterapp.ui.staff
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.studentcenterapp.data.staff.StaffRepository
+import com.example.studentcenterapp.model.Appointment
+import com.example.studentcenterapp.ui.state.UiState
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class StaffDashboardViewModel(
+    private val staffId: String,
+    private val repository: StaffRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<UiState<List<Appointment>>>(UiState.Loading)
+    val uiState: StateFlow<UiState<List<Appointment>>> = _uiState.asStateFlow()
+
+    private val _actionError = MutableStateFlow<String?>(null)
+    val actionError: StateFlow<String?> = _actionError.asStateFlow()
+
+    private val _actionLoading = MutableStateFlow(false)
+    val actionLoading: StateFlow<Boolean> = _actionLoading.asStateFlow()
+
+    init {
+        observePending()
+    }
+
+    private fun observePending() {
+        viewModelScope.launch {
+            _uiState.value = UiState.Loading
+            try {
+                repository.getPendingAppointmentsForStaff(staffId).collect { list ->
+                    _uiState.value = UiState.Success(list)
+                }
+            } catch (e: Exception) {
+                _uiState.value = UiState.Error(e.message ?: "Failed to load pending appointments")
+            }
+        }
+    }
+
+    fun approve(appointmentId: String) = update(appointmentId, approve = true)
+    fun reject(appointmentId: String) = update(appointmentId, approve = false)
+
+    private fun update(appointmentId: String, approve: Boolean) {
+        viewModelScope.launch {
+            _actionError.value = null
+            _actionLoading.value = true
+
+            val result = if (approve) {
+                repository.approveAppointment(appointmentId)
+            } else {
+                repository.rejectAppointment(appointmentId)
+            }
+
+            _actionLoading.value = false
+            if (result.isFailure) {
+                _actionError.value = result.exceptionOrNull()?.message ?: "Action failed"
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/studentcenterapp/ui/staff/StaffDashboardViewModelFactory.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/staff/StaffDashboardViewModelFactory.kt
@@ -1,0 +1,19 @@
+package com.example.studentcenterapp.ui.staff
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.studentcenterapp.data.staff.StaffRepository
+
+class StaffDashboardViewModelFactory(
+    private val staffId: String,
+    private val repository: StaffRepository
+) : ViewModelProvider.Factory {
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(StaffDashboardViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return StaffDashboardViewModel(staffId, repository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
+    }
+}


### PR DESCRIPTION
Implemented StaffDashboardScreen and StaffDashboardViewModel for staff pending-appointment workflow.
Screen displays pending appointments with loading/error states, includes approve/reject actions per item, and updates the list automatically via Flow (no app restart).
Navigation is wired from Welcome to staffDashboard/{staffId} and bottom bar UI matches the student layout.
CLOSES #15 