### PR TITLE
Add reusable EmptyStateScreen component (Closes #16)

### DIFF
--- a/app/src/main/java/com/example/studentcenterapp/ui/common/EmptyStateConfig.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/common/EmptyStateConfig.kt
@@ -1,0 +1,8 @@
+package com.example.studentcenterapp.ui.common
+
+data class EmptyStateConfig(
+    val title: String,
+    val message: String,
+    val actionText: String? = null,
+    val onAction: (() -> Unit)? = null
+)

--- a/app/src/main/java/com/example/studentcenterapp/ui/common/EmptyStateScreen.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/common/EmptyStateScreen.kt
@@ -1,0 +1,45 @@
+package com.example.studentcenterapp.ui.common
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun EmptyStateScreen(
+    config: EmptyStateConfig,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp, vertical = 24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = config.title,
+            style = MaterialTheme.typography.titleLarge
+        )
+        Spacer(Modifier.height(10.dp))
+        Text(
+            text = config.message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        val actionText = config.actionText
+        val onAction = config.onAction
+        if (!actionText.isNullOrBlank() && onAction != null) {
+            Spacer(Modifier.height(16.dp))
+            PrimaryButton(text = actionText, onClick = onAction)
+        }
+    }
+}

--- a/app/src/main/java/com/example/studentcenterapp/ui/staff/StaffDashboardScreen.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/staff/StaffDashboardScreen.kt
@@ -22,6 +22,9 @@ import com.example.studentcenterapp.model.Appointment
 import com.example.studentcenterapp.ui.common.*
 import com.example.studentcenterapp.ui.state.UiState
 import com.example.studentcenterapp.ui.theme.PrimaryBlue
+import com.example.studentcenterapp.ui.common.EmptyStateConfig
+import com.example.studentcenterapp.ui.common.EmptyStateScreen
+
 
 private val GrayPanel = Color(0xFFE9E9E9)     // büyük gri zemin
 private val GrayCard  = Color(0xFFDADADA)     // list item kart gri
@@ -143,24 +146,44 @@ fun StaffDashboardScreen(
                                     StaffTab.ALL -> all
                                 }
 
-                                LazyColumn(
-                                    verticalArrangement = Arrangement.spacedBy(12.dp),
-                                    modifier = Modifier.fillMaxWidth()
-                                ) {
-                                    items(filtered, key = { it.id }) { appt ->
-                                        StaffAppointmentCard(
-                                            name = appt.studentId,     // şimdilik studentId gösteriyoruz
-                                            time = appt.timeSlotId,    // şimdilik timeSlotId gösteriyoruz
-                                            status = appt.status,
-                                            actionLoading = actionLoading,
-                                            showActions = (selected == StaffTab.PENDING),
-                                            onApprove = { onApprove(appt.id) },
-                                            onReject = { onReject(appt.id) }
-                                        )
+                                if (filtered.isEmpty()) {
+                                    val (title, message) = when (selected) {
+                                        StaffTab.PENDING -> "No pending appointments" to "There are no pending requests right now."
+                                        StaffTab.ACTIVE -> "No active appointments" to "There are no active appointments right now."
+                                        StaffTab.CANCELLED -> "No cancelled appointments" to "There are no cancelled appointments right now."
+                                        StaffTab.ALL -> "No appointments" to "There are no appointments to show."
                                     }
-                                    item { Spacer(Modifier.height(8.dp)) }
+
+                                    EmptyStateScreen(
+                                        config = EmptyStateConfig(
+                                            title = title,
+                                            message = message
+                                        ),
+                                        modifier = Modifier
+                                            .fillMaxWidth()
+                                            .padding(vertical = 18.dp)
+                                    )
+                                } else {
+                                    LazyColumn(
+                                        verticalArrangement = Arrangement.spacedBy(12.dp),
+                                        modifier = Modifier.fillMaxWidth()
+                                    ) {
+                                        items(filtered, key = { it.id }) { appt ->
+                                            StaffAppointmentCard(
+                                                name = appt.studentId,
+                                                time = appt.timeSlotId,
+                                                status = appt.status,
+                                                actionLoading = actionLoading,
+                                                showActions = (selected == StaffTab.PENDING),
+                                                onApprove = { onApprove(appt.id) },
+                                                onReject = { onReject(appt.id) }
+                                            )
+                                        }
+                                        item { Spacer(Modifier.height(8.dp)) }
+                                    }
                                 }
                             }
+
                         }
                     }
                 }


### PR DESCRIPTION
Added reusable EmptyStateScreen composable for no-content scenarios.

Introduced EmptyStateConfig (title, message, optional action) to customize empty state per screen.

Integrated EmptyState into Staff Dashboard when filtered appointment list is empty.

CLOSES #16 