### PR TITLE
Add shared LoadingView and ErrorView components (Closes #17)

### DIFF
--- a/app/src/main/java/com/example/studentcenterapp/ui/common/ErrorView.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/common/ErrorView.kt
@@ -1,0 +1,45 @@
+package com.example.studentcenterapp.ui.common
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ErrorView(
+    message: String,
+    onRetry: (() -> Unit)? = null,
+    modifier: Modifier = Modifier
+) {
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .padding(horizontal = 24.dp, vertical = 24.dp),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Something went wrong",
+            style = MaterialTheme.typography.titleLarge
+        )
+        Spacer(Modifier.height(10.dp))
+        Text(
+            text = message,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+
+        if (onRetry != null) {
+            Spacer(Modifier.height(16.dp))
+            PrimaryButton(text = "Retry", onClick = onRetry)
+        }
+    }
+}

--- a/app/src/main/java/com/example/studentcenterapp/ui/common/LoadingView.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/common/LoadingView.kt
@@ -1,0 +1,23 @@
+package com.example.studentcenterapp.ui.common
+
+class LoadingView {
+}package com.example.studentcenterapp.ui.common
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+@Composable
+fun LoadingView(
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center
+    ) {
+        CircularProgressIndicator()
+    }
+}

--- a/app/src/main/java/com/example/studentcenterapp/ui/service/ServiceListScreen.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/service/ServiceListScreen.kt
@@ -2,20 +2,17 @@ package com.example.studentcenterapp.ui.service
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.example.studentcenterapp.model.Service
@@ -23,6 +20,10 @@ import com.example.studentcenterapp.ui.common.AppBottomBar
 import com.example.studentcenterapp.ui.common.AppTab
 import com.example.studentcenterapp.ui.common.AppTopBar
 import com.example.studentcenterapp.ui.common.ContentCard
+import com.example.studentcenterapp.ui.common.EmptyStateConfig
+import com.example.studentcenterapp.ui.common.EmptyStateScreen
+import com.example.studentcenterapp.ui.common.ErrorView
+import com.example.studentcenterapp.ui.common.LoadingView
 import com.example.studentcenterapp.ui.common.bottomTabs
 import com.example.studentcenterapp.ui.state.UiState
 import com.example.studentcenterapp.ui.theme.PrimaryBlue
@@ -32,7 +33,8 @@ fun ServiceListScreen(
     state: UiState<List<Service>>,
     currentRoute: String?,
     onTabSelected: (AppTab) -> Unit,
-    onServiceClick: (serviceId: String) -> Unit
+    onServiceClick: (serviceId: String) -> Unit,
+    onRetry: (() -> Unit)? = null // optional (istersen VM.loadServices bağlarsın)
 ) {
     Scaffold(
         topBar = { AppTopBar(title = "Services") },
@@ -45,47 +47,46 @@ fun ServiceListScreen(
         },
         containerColor = PrimaryBlue
     ) { innerPadding ->
-        Column(
+
+        ContentCard(
             modifier = Modifier
                 .fillMaxSize()
                 .padding(innerPadding)
         ) {
-            ContentCard(modifier = Modifier.fillMaxSize()) {
-                when (state) {
-                    is UiState.Loading -> {
-                        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                            CircularProgressIndicator()
-                        }
-                    }
+            when (state) {
+                is UiState.Loading -> {
+                    LoadingView()
+                }
 
-                    is UiState.Error -> {
-                        Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                            Text(
-                                text = state.message,
-                                style = MaterialTheme.typography.bodyLarge
+                is UiState.Error -> {
+                    ErrorView(
+                        message = state.message,
+                        onRetry = onRetry
+                    )
+                }
+
+                is UiState.Success -> {
+                    val services = state.data
+
+                    if (services.isEmpty()) {
+                        EmptyStateScreen(
+                            config = EmptyStateConfig(
+                                title = "No services",
+                                message = "This department has no services right now."
                             )
-                        }
-                    }
-
-                    is UiState.Success -> {
-                        val services = state.data
-                        if (services.isEmpty()) {
-                            Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                                Text("No services found.", style = MaterialTheme.typography.bodyLarge)
-                            }
-                        } else {
-                            LazyColumn(
-                                modifier = Modifier
-                                    .fillMaxSize()
-                                    .padding(horizontal = 21.dp, vertical = 16.dp),
-                                verticalArrangement = Arrangement.spacedBy(12.dp)
-                            ) {
-                                items(services, key = { it.id }) { service ->
-                                    ServiceListItem(
-                                        service = service,
-                                        onClick = { onServiceClick(service.id) }
-                                    )
-                                }
+                        )
+                    } else {
+                        LazyColumn(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .padding(horizontal = 21.dp, vertical = 16.dp),
+                            verticalArrangement = Arrangement.spacedBy(12.dp)
+                        ) {
+                            items(services, key = { it.id }) { service ->
+                                ServiceListItem(
+                                    service = service,
+                                    onClick = { onServiceClick(service.id) }
+                                )
                             }
                         }
                     }

--- a/app/src/main/java/com/example/studentcenterapp/ui/staff/StaffDashboardScreen.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/staff/StaffDashboardScreen.kt
@@ -24,6 +24,9 @@ import com.example.studentcenterapp.ui.state.UiState
 import com.example.studentcenterapp.ui.theme.PrimaryBlue
 import com.example.studentcenterapp.ui.common.EmptyStateConfig
 import com.example.studentcenterapp.ui.common.EmptyStateScreen
+import com.example.studentcenterapp.ui.common.LoadingView
+import com.example.studentcenterapp.ui.common.ErrorView
+
 
 
 private val GrayPanel = Color(0xFFE9E9E9)     // büyük gri zemin
@@ -129,13 +132,23 @@ fun StaffDashboardScreen(
 
                         when (state) {
                             is UiState.Loading -> {
-                                Box(Modifier.fillMaxWidth().padding(vertical = 30.dp), contentAlignment = Alignment.Center) {
-                                    CircularProgressIndicator()
-                                }
+                                LoadingView(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(vertical = 30.dp)
+                                )
                             }
+
                             is UiState.Error -> {
-                                Text(state.message, modifier = Modifier.padding(12.dp))
+                                ErrorView(
+                                    message = state.message,
+                                    onRetry = null,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(vertical = 18.dp)
+                                )
                             }
+
                             is UiState.Success -> {
                                 val all = state.data
 
@@ -183,7 +196,6 @@ fun StaffDashboardScreen(
                                     }
                                 }
                             }
-
                         }
                     }
                 }


### PR DESCRIPTION
Added reusable LoadingView and ErrorView components in ui/common.

Replaced duplicated loading/error UI in ServiceList and StaffDashboard screens.

Ensured consistent visuals by using shared typography and PrimaryButton for retry.

Closes #17 