### PR TITLE
Add staffId to Appointment model and update staff unit tests (Closes  #18)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -53,6 +53,11 @@ dependencies {
     implementation("androidx.compose.material:material-icons-extended")
 
     testImplementation(libs.junit)
+    testImplementation(libs.junit4)
+    testImplementation(libs.coroutines.test)
+    testImplementation(libs.turbine)
+
+
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
     androidTestImplementation(platform(libs.androidx.compose.bom))

--- a/app/src/androidTest/java/com/example/studentcenterapp/ui/service/ServiceListViewModelTest.kt
+++ b/app/src/androidTest/java/com/example/studentcenterapp/ui/service/ServiceListViewModelTest.kt
@@ -1,0 +1,69 @@
+package com.example.studentcenterapp.ui.service
+
+import com.example.studentcenterapp.data.service.ServiceRepository
+import com.example.studentcenterapp.model.Service
+import com.example.studentcenterapp.ui.state.UiState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ServiceListViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before fun setup() { Dispatchers.setMain(dispatcher) }
+    @After fun tearDown() { Dispatchers.resetMain() }
+
+    @Test
+    fun loadServices_setsSuccess_whenRepositoryReturnsList() = runTest {
+        val repo = FakeRepo(
+            flowOf(
+                listOf(
+                    Service(
+                        id = "1",
+                        name = "S1",
+                        description = "Desc",
+                        durationMinutes = 30,
+                        departmentId = "D1"
+                    )
+                )
+            )
+        )
+
+        val vm = ServiceListViewModel(repo)
+
+        vm.loadServices("D1")
+        advanceUntilIdle()
+
+        val state = vm.uiState.value
+        assertTrue(state is UiState.Success && state.data.isNotEmpty())
+    }
+
+    @Test
+    fun loadServices_setsError_whenRepositoryThrows() = runTest {
+        val repo = FakeRepo(flow { throw RuntimeException("boom") })
+        val vm = ServiceListViewModel(repo)
+
+        vm.loadServices("D1")
+        advanceUntilIdle()
+
+        val state = vm.uiState.value
+        assertTrue(state is UiState.Error && state.message.contains("boom"))
+    }
+
+    private class FakeRepo(private val source: Flow<List<Service>>) : ServiceRepository {
+        override fun getServicesByDepartment(departmentId: String): Flow<List<Service>> = source
+    }
+}

--- a/app/src/androidTest/java/com/example/studentcenterapp/ui/staff/StaffDashboardViewModelTest.kt
+++ b/app/src/androidTest/java/com/example/studentcenterapp/ui/staff/StaffDashboardViewModelTest.kt
@@ -1,0 +1,150 @@
+package com.example.studentcenterapp.ui.staff
+
+import com.example.studentcenterapp.data.staff.StaffRepository
+import com.example.studentcenterapp.model.Appointment
+import com.example.studentcenterapp.ui.state.UiState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StaffDashboardViewModelTest {
+
+    private val dispatcher = StandardTestDispatcher()
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(dispatcher)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun loadsPendingAppointmentsForStaff() = runTest {
+        val repo = FakeStaffRepo().apply {
+            seed(
+                listOf(
+                    appt(id = "a1", staffId = "staff1", status = "pending"),
+                    appt(id = "a2", staffId = "staff1", status = "pending"),
+                    appt(id = "a3", staffId = "staff2", status = "pending"),
+                    appt(id = "a4", staffId = "staff1", status = "approved")
+                )
+            )
+        }
+
+        val vm = StaffDashboardViewModel(staffId = "staff1", repository = repo)
+
+        advanceUntilIdle()
+
+        val state = vm.uiState.value
+        assertTrue(state is UiState.Success)
+
+        val list = (state as UiState.Success<List<Appointment>>).data
+        assertEquals(2, list.size)
+        assertTrue(list.all { it.staffId == "staff1" && it.status == "pending" })
+    }
+
+    @Test
+    fun approveUpdatesStatusAndRemovesFromPending() = runTest {
+        val repo = FakeStaffRepo().apply {
+            seed(listOf(appt(id = "a1", staffId = "staff1", status = "pending")))
+        }
+
+        val vm = StaffDashboardViewModel(staffId = "staff1", repository = repo)
+
+        advanceUntilIdle()
+
+        vm.approve("a1")
+        advanceUntilIdle()
+
+        val state = vm.uiState.value
+        assertTrue(state is UiState.Success)
+
+        val list = (state as UiState.Success<List<Appointment>>).data
+        assertTrue(list.isEmpty())
+    }
+
+    @Test
+    fun rejectInvalidIdSetsActionErrorWithoutCrash() = runTest {
+        val repo = FakeStaffRepo().apply { seed(emptyList()) }
+        val vm = StaffDashboardViewModel(staffId = "staff1", repository = repo)
+
+        advanceUntilIdle()
+
+        vm.reject("missing")
+        advanceUntilIdle()
+
+        val err = vm.actionError.value
+        assertTrue(!err.isNullOrBlank())
+    }
+
+    private class FakeStaffRepo : StaffRepository {
+
+        private val store = mutableMapOf<String, Appointment>()
+        private val pendingFlow = MutableStateFlow<List<Appointment>>(emptyList())
+
+        fun seed(list: List<Appointment>) {
+            store.clear()
+            list.forEach { store[it.id] = it }
+            emitFor("staff1")
+            emitFor("staff2")
+        }
+
+        private fun emitFor(staffId: String) {
+            val pending = store.values
+                .filter { it.staffId == staffId && it.status == "pending" }
+                .sortedBy { it.id }
+
+            // tek flow tutuyoruz; testte sadece staff1'e bakıyoruz
+            if (staffId == "staff1") pendingFlow.value = pending
+        }
+
+        override fun getPendingAppointmentsForStaff(staffId: String): Flow<List<Appointment>> {
+            // basit: sadece staff1’i simüle ediyoruz
+            return pendingFlow.asStateFlow()
+        }
+
+        override suspend fun approveAppointment(appointmentId: String): Result<Unit> {
+            val a = store[appointmentId]
+                ?: return Result.failure(IllegalArgumentException("Invalid appointmentId"))
+
+            store[appointmentId] = a.copy(status = "approved")
+            emitFor(a.staffId)
+            return Result.success(Unit)
+        }
+
+        override suspend fun rejectAppointment(appointmentId: String): Result<Unit> {
+            val a = store[appointmentId]
+                ?: return Result.failure(IllegalArgumentException("Invalid appointmentId"))
+
+            store[appointmentId] = a.copy(status = "cancelled")
+            emitFor(a.staffId)
+            return Result.success(Unit)
+        }
+    }
+
+    private fun appt(id: String, staffId: String, status: String) =
+        Appointment(
+            id = id,
+            studentId = "s1",
+            staffId = staffId,
+            serviceId = "svc1",
+            timeSlotId = "t1",
+            status = status
+        )
+}

--- a/app/src/main/java/com/example/studentcenterapp/model/Appointment.kt
+++ b/app/src/main/java/com/example/studentcenterapp/model/Appointment.kt
@@ -3,6 +3,7 @@ package com.example.studentcenterapp.model
 data class Appointment(
     val id: String,
     val studentId: String,
+    val staffId: String,
     val serviceId: String,
     val timeSlotId: String,
     val status: String // "pending" | "approved" | "cancelled"

--- a/app/src/main/java/com/example/studentcenterapp/navigation/StudentCenterNavHost.kt
+++ b/app/src/main/java/com/example/studentcenterapp/navigation/StudentCenterNavHost.kt
@@ -1,35 +1,36 @@
 package com.example.studentcenterapp.navigation
 
-import com.example.studentcenterapp.ui.staff.StaffDashboardScreen
-import com.example.studentcenterapp.ui.staff.StaffDashboardViewModel
-import com.example.studentcenterapp.ui.staff.StaffDashboardViewModelFactory
-import androidx.compose.runtime.LaunchedEffect
-import com.example.studentcenterapp.ui.service.ServiceListScreen
-import com.example.studentcenterapp.ui.service.ServiceListViewModel
-import com.example.studentcenterapp.ui.service.ServiceListViewModelFactory
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import com.example.studentcenterapp.ui.theme.StudentCenterTheme
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.studentcenterapp.data.AppDI
+import com.example.studentcenterapp.ui.service.ServiceListScreen
+import com.example.studentcenterapp.ui.service.ServiceListViewModel
+import com.example.studentcenterapp.ui.service.ServiceListViewModelFactory
 import com.example.studentcenterapp.ui.splash.SplashScreen
 import com.example.studentcenterapp.ui.splash.WelcomeScreen
+import com.example.studentcenterapp.ui.staff.StaffDashboardScreen
+import com.example.studentcenterapp.ui.staff.StaffDashboardViewModel
+import com.example.studentcenterapp.ui.staff.StaffDashboardViewModelFactory
+import com.example.studentcenterapp.ui.theme.StudentCenterTheme
 import com.example.studentcenterapp.viewmodel.department.DepartmentListScreen
 import com.example.studentcenterapp.viewmodel.department.DepartmentListViewModel
 import com.example.studentcenterapp.viewmodel.department.DepartmentListViewModelFactory
 import com.example.studentcenterapp.viewmodel.splash.SplashViewModel
+
 @Composable
 fun StudentCenterApp() {
     StudentCenterTheme {
@@ -48,13 +49,14 @@ fun StudentCenterNavHost(
         navController = navController,
         startDestination = Screen.Splash.route
     ) {
+
+        // Splash
         composable(Screen.Splash.route) {
             val splashViewModel: SplashViewModel = viewModel()
 
             SplashScreen(
                 onFinished = {
                     navController.navigate(Screen.Welcome.route) {
-                        // Geri tuşuna basınca Splash’e dönmeyelim
                         popUpTo(Screen.Splash.route) { inclusive = true }
                     }
                 },
@@ -62,42 +64,39 @@ fun StudentCenterNavHost(
             )
         }
 
+        // Welcome (Student / Staff entry)
         composable(Screen.Welcome.route) {
             WelcomeScreen(
-                onStudentClick = { navController.navigate(Screen.Departments.route)
+                onStudentClick = {
+                    navController.navigate(Screen.Departments.route)
                 },
                 onStaffClick = {
-                    navController.navigate("staffDashboard/staff1")
+                    navController.navigate("staffDashboard/staff1?entry=staff")
                 }
             )
         }
 
-
-        //same
+        // Departments
         composable(Screen.Departments.route) {
-
             val vm: DepartmentListViewModel = viewModel(
                 factory = DepartmentListViewModelFactory(AppDI.departmentRepository)
             )
 
             val state by vm.uiState.collectAsState()
 
-
             DepartmentListScreen(
                 state = state,
                 currentRoute = Screen.Departments.route,
                 onTabSelected = { tab ->
-                    navController.navigate(tab.route) {
-                        launchSingleTop = true
-                    }
+                    navController.navigate(tab.route) { launchSingleTop = true }
                 },
                 onDepartmentClick = { departmentId ->
-                    // Şimdilik services yoksa placeholder'a gidebilirsin
                     navController.navigate("services/$departmentId")
                 }
             )
         }
 
+        // Services by Department
         composable("services/{departmentId}") { backStackEntry ->
             val departmentId = backStackEntry.arguments?.getString("departmentId").orEmpty()
 
@@ -118,12 +117,25 @@ fun StudentCenterNavHost(
                 },
                 onServiceClick = { serviceId ->
                     navController.navigate("slots/$serviceId")
+                },
+                onRetry = {
+                    if (departmentId.isNotBlank()) vm.loadServices(departmentId)
                 }
             )
         }
-
-        composable("staffDashboard/{staffId}") { backStackEntry ->
+        
+        composable("staffDashboard/{staffId}?entry={entry}") { backStackEntry ->
             val staffId = backStackEntry.arguments?.getString("staffId").orEmpty()
+            val entry = backStackEntry.arguments?.getString("entry").orEmpty()
+
+            // Guard: prevent direct navigation without staff entry token
+            if (staffId.isBlank() || entry != "staff") {
+                navController.navigate(Screen.Welcome.route) {
+                    popUpTo(Screen.Welcome.route) { inclusive = false }
+                    launchSingleTop = true
+                }
+                return@composable
+            }
 
             val vm: StaffDashboardViewModel = viewModel(
                 factory = StaffDashboardViewModelFactory(staffId, AppDI.staffRepository)
@@ -137,40 +149,27 @@ fun StudentCenterNavHost(
                 state = state,
                 actionLoading = actionLoading,
                 actionError = actionError,
-                currentRoute = Screen.StaffDashboard.route,
+                currentRoute = null,
                 onTabSelected = { tab ->
                     navController.navigate(tab.route) { launchSingleTop = true }
                 },
                 onApprove = { vm.approve(it) },
                 onReject = { vm.reject(it) }
             )
-
         }
 
-
-
-        composable(Screen.Services.route) {
-            PlaceholderScreen("Services")
-        }
-
+        // Slots (placeholder)
         composable("slots/{serviceId}") { backStackEntry ->
             val serviceId = backStackEntry.arguments?.getString("serviceId").orEmpty()
             PlaceholderScreen("Slots for serviceId = $serviceId")
         }
 
+        // Other placeholders
+        composable(Screen.Services.route) { PlaceholderScreen("Services") }
+        composable(Screen.Slots.route) { PlaceholderScreen("Slots") }
+        composable(Screen.Confirm.route) { PlaceholderScreen("Confirm") }
+        composable(Screen.Appointments.route) { PlaceholderScreen("Appointments") }
 
-        composable(Screen.Slots.route) {
-            PlaceholderScreen("Slots")
-        }
-        composable(Screen.Confirm.route) {
-            PlaceholderScreen("Confirm")
-        }
-        composable(Screen.Appointments.route) {
-            PlaceholderScreen("Appointments")
-        }
-        composable(Screen.StaffDashboard.route) {
-            PlaceholderScreen("Staff Dashboard")
-        }
     }
 }
 
@@ -183,6 +182,7 @@ private fun PlaceholderScreen(name: String) {
         Text(text = "TODO: $name screen")
     }
 }
+
 @Preview(showBackground = true)
 @Composable
 fun StudentCenterAppPreview() {

--- a/app/src/main/java/com/example/studentcenterapp/ui/common/LoadingView.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/common/LoadingView.kt
@@ -1,8 +1,5 @@
 package com.example.studentcenterapp.ui.common
 
-class LoadingView {
-}package com.example.studentcenterapp.ui.common
-
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+org.gradle.java.home=C\:\\Program Files\\Android\\Android Studio\\jbr
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,10 @@ okhttp = "4.12.0"
 moshi = "1.15.2"
 lifecycle = "2.9.1"
 navigation = "2.9.4"
+junit4 = "4.13.2"
+coroutinesTest = "1.8.1"
+turbine = "1.1.0"
+
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -41,6 +45,11 @@ lifecycle-viewmodel = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", v
 lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 
 navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigation" }
+
+junit4 = { module = "junit:junit", version.ref = "junit4" }
+coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutinesTest" }
+turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
+
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Summary

Added staffId to Appointment model to support staff-specific appointment flows.

Updated staff unit tests to use the new model and validate pending/approve/reject behavior.

Why

StaffRepository APIs require filtering pending appointments by staffId.

Aligns data model with staff dashboard and navigation requirements.

Changes

model/Appointment.kt: added staffId

StaffDashboardViewModelTest: updated appointment factory + assertions

Testing

./gradlew :app:testDebugUnitTest

CLOSES #18 