### PR TITLE
Fix appointment staffId wiring in in-memory staff datasource

### DIFF
--- a/app/src/main/java/com/example/studentcenterapp/data/staff/InMemoryAppointmentAdminDataSource.kt
+++ b/app/src/main/java/com/example/studentcenterapp/data/staff/InMemoryAppointmentAdminDataSource.kt
@@ -12,6 +12,7 @@ class InMemoryAppointmentAdminDataSource : AppointmentAdminDataSource {
             Appointment(
                 id = "a1",
                 studentId = "s1",
+                staffId = "staff1",
                 serviceId = "srv1",
                 timeSlotId = "t1",
                 status = STATUS_PENDING
@@ -19,6 +20,7 @@ class InMemoryAppointmentAdminDataSource : AppointmentAdminDataSource {
             Appointment(
                 id = "a2",
                 studentId = "s2",
+                staffId = "staff1",
                 serviceId = "srv2",
                 timeSlotId = "t2",
                 status = STATUS_PENDING
@@ -26,6 +28,7 @@ class InMemoryAppointmentAdminDataSource : AppointmentAdminDataSource {
             Appointment(
                 id = "a3",
                 studentId = "s3",
+                staffId = "staff2",
                 serviceId = "srv3",
                 timeSlotId = "t3",
                 status = STATUS_APPROVED
@@ -33,17 +36,10 @@ class InMemoryAppointmentAdminDataSource : AppointmentAdminDataSource {
         )
     )
 
-    // Appointment modelinde staffId yok → staff assignment’ı burada tutuyoruz.
-    // TODO: shared InMemoryDataSource / AppointmentRepository ile birleşecek (Şahan + Selimcan)
-    private val assignment: Map<String, String> = mapOf(
-        "a1" to "staff1",
-        "a2" to "staff1",
-        "a3" to "staff2"
-    )
-
     override fun observeAppointments(): Flow<List<Appointment>> = _appointments.asStateFlow()
 
-    override fun getAssignedStaffId(appointmentId: String): String? = assignment[appointmentId]
+    override fun getAssignedStaffId(appointmentId: String): String? =
+        _appointments.value.firstOrNull { it.id == appointmentId }?.staffId
 
     override suspend fun updateStatus(appointmentId: String, newStatus: String): Boolean {
         val current = _appointments.value
@@ -58,6 +54,6 @@ class InMemoryAppointmentAdminDataSource : AppointmentAdminDataSource {
     companion object {
         const val STATUS_PENDING = "pending"
         const val STATUS_APPROVED = "approved"
-        const val STATUS_CANCELLED = "cancelled" // reject için bunu kullanıyoruz
+        const val STATUS_CANCELLED = "cancelled"
     }
 }


### PR DESCRIPTION
Summary

Fixed build failure after adding staffId to Appointment.

Updated InMemoryAppointmentAdminDataSource seed data to include staffId.

Simplified staff assignment lookup by reading staffId directly from stored appointments.

Changes

model/Appointment.kt: added staffId field.

data/staff/InMemoryAppointmentAdminDataSource.kt: updated seeded Appointment objects to pass staffId; getAssignedStaffId now uses appointment data.

Why

Compile error: No value passed for parameter 'staffId' in staff in-memory datasource.

Testing

./gradlew :app:assembleDebug (should compile after this change)

Notes

Keeps staff assignment fully in the shared Appointment model; removes the need for separate assignment map for in-memory flow.