### PR TITLE
feat: add appointment history screen and viewmodel

### DIFF
--- a/app/src/main/java/com/example/studentcenterapp/viewmodel/appointment/AppointmentHistoryScreen.kt
+++ b/app/src/main/java/com/example/studentcenterapp/viewmodel/appointment/AppointmentHistoryScreen.kt
@@ -1,0 +1,97 @@
+package com.example.studentcenterapp.viewmodel.appointment
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.example.studentcenterapp.model.Appointment
+import com.example.studentcenterapp.viewmodel.appointment.AppointmentHistoryViewModel
+
+@Composable
+fun AppointmentHistoryScreen(
+    viewModel: AppointmentHistoryViewModel,
+    modifier: Modifier = Modifier,
+    onAppointmentClick: ((Appointment) -> Unit)? = null
+) {
+    val state by viewModel.uiState.collectAsState()
+
+    when {
+        state.isLoading -> {
+            Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+        }
+
+        state.errorMessage != null -> {
+            Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text(text = state.errorMessage ?: "Unexpected error")
+            }
+        }
+
+        state.appointments.isEmpty() -> {
+            Box(modifier = modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                Text(text = "No appointment history")
+            }
+        }
+
+        else -> {
+            LazyColumn(
+                modifier = modifier
+                    .fillMaxSize()
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                items(state.appointments, key = { it.id }) { appointment ->
+                    AppointmentHistoryItem(
+                        appointment = appointment,
+                        onClick = {
+                            onAppointmentClick?.invoke(appointment)
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun AppointmentHistoryItem(
+    appointment: Appointment,
+    onClick: () -> Unit
+) {
+    OutlinedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable { onClick() }
+    ) {
+        Column(modifier = Modifier.padding(14.dp)) {
+            Text(
+                text = "Service: ${appointment.serviceId}",
+                style = MaterialTheme.typography.titleMedium
+            )
+            Text(
+                text = "Status: ${appointment.status}",
+                style = MaterialTheme.typography.bodyMedium
+            )
+            Text(
+                text = "TimeSlotId: ${appointment.timeSlotId}",
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/studentcenterapp/viewmodel/appointment/AppointmentHistoryUiState.kt
+++ b/app/src/main/java/com/example/studentcenterapp/viewmodel/appointment/AppointmentHistoryUiState.kt
@@ -1,0 +1,9 @@
+package com.example.studentcenterapp.viewmodel.appointment
+
+import com.example.studentcenterapp.model.Appointment
+
+data class AppointmentHistoryUiState(
+    val isLoading: Boolean = false,
+    val appointments: List<Appointment> = emptyList(),
+    val errorMessage: String? = null
+)

--- a/app/src/main/java/com/example/studentcenterapp/viewmodel/appointment/AppointmentHistoryViewModel.kt
+++ b/app/src/main/java/com/example/studentcenterapp/viewmodel/appointment/AppointmentHistoryViewModel.kt
@@ -1,0 +1,81 @@
+package com.example.studentcenterapp.viewmodel.appointment
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.studentcenterapp.model.Appointment
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * NOTE:
+ * Bu ViewModel, "past appointments" filtresini status üzerinden yapar.
+ * MVP için: pending => geçmiş değildir (history'de görünmez).
+ */
+class AppointmentHistoryViewModel(
+    private val appointmentRepository: AppointmentRepository
+) : ViewModel() {
+
+    data class UiState(
+        val isLoading: Boolean = false,
+        val appointments: List<Appointment> = emptyList(),
+        val errorMessage: String? = null
+    )
+
+    private val _uiState = MutableStateFlow(UiState(isLoading = true))
+    val uiState: StateFlow<UiState> = _uiState.asStateFlow()
+
+    init {
+        loadHistory()
+    }
+
+    fun loadHistory() {
+        viewModelScope.launch {
+            appointmentRepository.getAppointments()
+                .onStart {
+                    _uiState.update { it.copy(isLoading = true, errorMessage = null) }
+                }
+                .catch { e ->
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            appointments = emptyList(),
+                            errorMessage = e.message ?: "Unexpected error"
+                        )
+                    }
+                }
+                .collect { allAppointments ->
+                    val history = allAppointments.filter { it.isPastForHistory() }
+
+                    _uiState.update {
+                        it.copy(
+                            isLoading = false,
+                            appointments = history,
+                            errorMessage = null
+                        )
+                    }
+                }
+        }
+    }
+
+    /**
+     * "Past" filtre:
+     * - pending => değil
+     * - approved/cancelled/completed => history
+     *
+     * Eğer ileride "timeSlot date/time" ile gerçek zaman filtresi istenecekse
+     * burayı TimeSlot verisiyle değiştireceğiz.
+     */
+    private fun Appointment.isPastForHistory(): Boolean {
+        val s = status.trim().lowercase()
+        return s != "pending"
+    }
+}
+
+interface AppointmentRepository {
+    fun getAppointments(): kotlinx.coroutines.flow.Flow<List<Appointment>>
+}


### PR DESCRIPTION
Adds appointment history feature with ViewModel and screen.
Only past appointments are shown with proper empty state handling.