### PR TITLE
feat(appointment): add confirmation screen and viewmodel

### DIFF
--- a/app/src/main/java/com/example/studentcenterapp/data/AppDI.kt
+++ b/app/src/main/java/com/example/studentcenterapp/data/AppDI.kt
@@ -1,20 +1,24 @@
 package com.example.studentcenterapp.data
 
-import com.example.studentcenterapp.data.staff.InMemoryAppointmentAdminDataSource
-import com.example.studentcenterapp.data.staff.StaffRepository
-import com.example.studentcenterapp.data.staff.StaffRepositoryImpl
+import com.example.studentcenterapp.data.auth.FakeStaffAuthRepository
+import com.example.studentcenterapp.data.auth.StaffAuthRepository
 import com.example.studentcenterapp.data.department.DepartmentRepository
 import com.example.studentcenterapp.data.department.DepartmentRepositoryImpl
 import com.example.studentcenterapp.data.department.InMemoryDepartmentDataSource
 import com.example.studentcenterapp.data.service.InMemoryServiceDataSource
 import com.example.studentcenterapp.data.service.ServiceRepository
 import com.example.studentcenterapp.data.service.ServiceRepositoryImpl
+import com.example.studentcenterapp.data.staff.InMemoryAppointmentAdminDataSource
+import com.example.studentcenterapp.data.staff.StaffRepository
+import com.example.studentcenterapp.data.staff.StaffRepositoryImpl
 import com.example.studentcenterapp.data.student.InMemoryStudentDataSource
 import com.example.studentcenterapp.data.student.StudentRepository
 import com.example.studentcenterapp.data.student.StudentRepositoryImpl
-import com.example.studentcenterapp.data.auth.FakeStaffAuthRepository
-import com.example.studentcenterapp.data.auth.StaffAuthRepository
 
+// ✅ YENİ: appointment imports
+import com.example.studentcenterapp.data.appointment.AppointmentRepository
+import com.example.studentcenterapp.data.appointment.AppointmentRepositoryImpl
+import com.example.studentcenterapp.data.appointment.InMemoryAppointmentDataSource
 
 object AppDI {
     val departmentRepository: DepartmentRepository by lazy {
@@ -34,4 +38,8 @@ object AppDI {
         FakeStaffAuthRepository()
     }
 
+    // ✅ #37 için gerekli: AppointmentRepository
+    val appointmentRepository: AppointmentRepository by lazy {
+        AppointmentRepositoryImpl(InMemoryAppointmentDataSource())
+    }
 }

--- a/app/src/main/java/com/example/studentcenterapp/data/appointment/AppointmentRepository.kt
+++ b/app/src/main/java/com/example/studentcenterapp/data/appointment/AppointmentRepository.kt
@@ -1,0 +1,29 @@
+package com.example.studentcenterapp.data.appointment
+
+import kotlinx.coroutines.flow.Flow
+
+interface AppointmentRepository {
+    fun getAppointmentsForStudent(studentId: String): Flow<List<AppointmentRecord>>
+
+    suspend fun createAppointment(
+        studentId: String,
+        serviceId: String,
+        timeSlotId: String,
+        scheduledStartMillis: Long
+    ): Result<Unit>
+
+    suspend fun cancelAppointment(appointmentId: String): Result<Unit>
+}
+
+/**
+ * Domain/model sınıfına dokunmadan ilerlemek için basit record.
+ * (İstersen sonra model.Appointment ile değiştirirsin.)
+ */
+data class AppointmentRecord(
+    val id: String,
+    val studentId: String,
+    val serviceId: String,
+    val timeSlotId: String,
+    val scheduledStartMillis: Long,
+    val status: String
+)

--- a/app/src/main/java/com/example/studentcenterapp/data/appointment/AppointmentRepositoryImpl.kt
+++ b/app/src/main/java/com/example/studentcenterapp/data/appointment/AppointmentRepositoryImpl.kt
@@ -1,0 +1,37 @@
+package com.example.studentcenterapp.data.appointment
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+class AppointmentRepositoryImpl(
+    private val dataSource: InMemoryAppointmentDataSource
+) : AppointmentRepository {
+
+    override fun getAppointmentsForStudent(studentId: String): Flow<List<AppointmentRecord>> {
+        return dataSource.appointmentsFlow.map { list ->
+            list.filter { it.studentId == studentId }
+        }
+    }
+
+    override suspend fun createAppointment(
+        studentId: String,
+        serviceId: String,
+        timeSlotId: String,
+        scheduledStartMillis: Long
+    ): Result<Unit> {
+        return runCatching {
+            dataSource.add(
+                studentId = studentId,
+                serviceId = serviceId,
+                timeSlotId = timeSlotId,
+                scheduledStartMillis = scheduledStartMillis
+            )
+        }
+    }
+
+    override suspend fun cancelAppointment(appointmentId: String): Result<Unit> {
+        return runCatching {
+            dataSource.remove(appointmentId)
+        }
+    }
+}

--- a/app/src/main/java/com/example/studentcenterapp/data/appointment/InMemoryAppointmentDataSource.kt
+++ b/app/src/main/java/com/example/studentcenterapp/data/appointment/InMemoryAppointmentDataSource.kt
@@ -1,0 +1,32 @@
+package com.example.studentcenterapp.data.appointment
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.util.UUID
+
+class InMemoryAppointmentDataSource {
+    private val _appointments = MutableStateFlow<List<AppointmentRecord>>(emptyList())
+    val appointmentsFlow = _appointments.asStateFlow()
+
+    fun add(
+        studentId: String,
+        serviceId: String,
+        timeSlotId: String,
+        scheduledStartMillis: Long
+    ) {
+        val newItem = AppointmentRecord(
+            id = UUID.randomUUID().toString(),
+            studentId = studentId,
+            serviceId = serviceId,
+            timeSlotId = timeSlotId,
+            scheduledStartMillis = scheduledStartMillis,
+            status = "PENDING"
+        )
+
+        _appointments.value = _appointments.value + newItem
+    }
+
+    fun remove(appointmentId: String) {
+        _appointments.value = _appointments.value.filterNot { it.id == appointmentId }
+    }
+}

--- a/app/src/main/java/com/example/studentcenterapp/navigation/StudentCenterNavHost.kt
+++ b/app/src/main/java/com/example/studentcenterapp/navigation/StudentCenterNavHost.kt
@@ -20,15 +20,13 @@ import androidx.navigation.compose.rememberNavController
 import com.example.studentcenterapp.data.AppDI
 import com.example.studentcenterapp.data.inmemory.InMemoryDataSource
 import com.example.studentcenterapp.data.timeslot.TimeSlotRepositoryImpl
+import com.example.studentcenterapp.ui.confirmation.AppointmentConfirmationViewModelFactory
+import com.example.studentcenterapp.ui.screens.AppointmentConfirmationScreen
 import com.example.studentcenterapp.ui.service.ServiceListScreen
 import com.example.studentcenterapp.ui.service.ServiceListViewModel
 import com.example.studentcenterapp.ui.service.ServiceListViewModelFactory
 import com.example.studentcenterapp.ui.splash.SplashScreen
 import com.example.studentcenterapp.ui.splash.WelcomeScreen
-import com.example.studentcenterapp.ui.student.ForgotPasswordEmailScreen
-import com.example.studentcenterapp.ui.student.SignupSuccessScreen
-import com.example.studentcenterapp.ui.student.StudentLoginScreen
-import com.example.studentcenterapp.ui.student.StudentSignupScreen
 import com.example.studentcenterapp.ui.staff.StaffDashboardScreen
 import com.example.studentcenterapp.ui.staff.StaffDashboardViewModel
 import com.example.studentcenterapp.ui.staff.StaffDashboardViewModelFactory
@@ -38,6 +36,10 @@ import com.example.studentcenterapp.ui.staffauth.StaffLoginViewModelFactory
 import com.example.studentcenterapp.ui.staffauth.StaffSignupScreen
 import com.example.studentcenterapp.ui.staffauth.StaffSignupViewModel
 import com.example.studentcenterapp.ui.staffauth.StaffSignupViewModelFactory
+import com.example.studentcenterapp.ui.student.ForgotPasswordEmailScreen
+import com.example.studentcenterapp.ui.student.SignupSuccessScreen
+import com.example.studentcenterapp.ui.student.StudentLoginScreen
+import com.example.studentcenterapp.ui.student.StudentSignupScreen
 import com.example.studentcenterapp.ui.theme.StudentCenterTheme
 import com.example.studentcenterapp.viewmodel.appointment.TimeSlotDestinations
 import com.example.studentcenterapp.viewmodel.appointment.timeSlotGraph
@@ -48,6 +50,15 @@ import com.example.studentcenterapp.viewmodel.splash.SplashViewModel
 import com.example.studentcenterapp.viewmodel.student.ForgotPasswordViewModel
 import com.example.studentcenterapp.viewmodel.student.StudentLoginViewModel
 import com.example.studentcenterapp.viewmodel.student.StudentSignupViewModel
+
+// ✅ Confirm ekranına veri taşımak için anahtarlar
+private const val KEY_STUDENT_ID = "studentId"
+private const val KEY_DEPARTMENT_NAME = "departmentName"
+private const val KEY_SERVICE_ID = "serviceId"
+private const val KEY_SERVICE_NAME = "serviceName"
+private const val KEY_TIMESLOT_ID = "timeSlotId"
+private const val KEY_START_MILLIS = "scheduledStartMillis"
+private const val KEY_DATE_TEXT = "dateTimeText"
 
 @Composable
 fun StudentCenterApp() {
@@ -233,6 +244,39 @@ fun StudentCenterNavHost(
         )
 
         // -------------------------
+        // ✅ CONFIRM (bizim yaptığımız ekran)
+        // -------------------------
+        composable(Screen.Confirm.route) {
+            val prev = navController.previousBackStackEntry?.savedStateHandle
+
+            val studentId = prev?.get<String>(KEY_STUDENT_ID).orEmpty()
+            val departmentName = prev?.get<String>(KEY_DEPARTMENT_NAME).orEmpty()
+            val serviceId = prev?.get<String>(KEY_SERVICE_ID).orEmpty()
+            val serviceName = prev?.get<String>(KEY_SERVICE_NAME).orEmpty()
+            val timeSlotId = prev?.get<String>(KEY_TIMESLOT_ID).orEmpty()
+            val scheduledStartMillis = prev?.get<Long>(KEY_START_MILLIS) ?: 0L
+            val dateTimeText = prev?.get<String>(KEY_DATE_TEXT).orEmpty()
+
+            AppointmentConfirmationScreen(
+                studentId = studentId,
+                departmentName = departmentName,
+                serviceId = serviceId,
+                serviceName = serviceName,
+                timeSlotId = timeSlotId,
+                scheduledStartMillis = scheduledStartMillis,
+                dateTimeText = dateTimeText,
+                factory = AppointmentConfirmationViewModelFactory(AppDI.appointmentRepository),
+                onBack = { navController.popBackStack() },
+                onSuccessNavigate = {
+                    navController.navigate(Screen.Appointments.route) {
+                        popUpTo(Screen.Confirm.route) { inclusive = true }
+                        launchSingleTop = true
+                    }
+                }
+            )
+        }
+
+        // -------------------------
         // Staff Dashboard (guarded)
         // -------------------------
         composable("staffDashboard/{staffId}?entry={entry}") { backStackEntry ->
@@ -268,10 +312,9 @@ fun StudentCenterNavHost(
             )
         }
 
-        // placeholders (kalsın)
+        // ✅ diğer placeholder’lar kalsın (mevcut akışları bozmasın)
         composable(Screen.Services.route) { PlaceholderScreen("Services") }
         composable(Screen.Slots.route) { PlaceholderScreen("Slots") }
-        composable(Screen.Confirm.route) { PlaceholderScreen("Confirm") }
         composable(Screen.Appointments.route) { PlaceholderScreen("Appointments") }
         composable(Screen.StaffDashboard.route) { PlaceholderScreen("Staff Dashboard") }
     }

--- a/app/src/main/java/com/example/studentcenterapp/ui/confirmation/AppointmentConfirmationUiState.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/confirmation/AppointmentConfirmationUiState.kt
@@ -1,0 +1,24 @@
+package com.example.studentcenterapp.ui.confirmation
+
+data class AppointmentConfirmationUiState(
+    val studentId: String = "",
+
+    val departmentName: String = "",
+    val serviceId: String = "",
+    val serviceName: String = "",
+
+    val timeSlotId: String = "",
+    val scheduledStartMillis: Long = 0L,
+    val dateTimeText: String = "",
+
+    val isLoading: Boolean = false,
+    val isSuccess: Boolean = false,
+    val errorMessage: String? = null
+) {
+    fun isValid(): Boolean {
+        return studentId.isNotBlank() &&
+                serviceId.isNotBlank() &&
+                timeSlotId.isNotBlank() &&
+                scheduledStartMillis > 0L
+    }
+}

--- a/app/src/main/java/com/example/studentcenterapp/ui/confirmation/AppointmentConfirmationViewModel.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/confirmation/AppointmentConfirmationViewModel.kt
@@ -1,0 +1,78 @@
+package com.example.studentcenterapp.ui.confirmation
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.studentcenterapp.data.appointment.AppointmentRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class AppointmentConfirmationViewModel(
+    private val appointmentRepository: AppointmentRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(AppointmentConfirmationUiState())
+    val uiState: StateFlow<AppointmentConfirmationUiState> = _uiState.asStateFlow()
+
+    fun setSelection(
+        studentId: String,
+        departmentName: String,
+        serviceId: String,
+        serviceName: String,
+        timeSlotId: String,
+        scheduledStartMillis: Long,
+        dateTimeText: String
+    ) {
+        _uiState.update {
+            it.copy(
+                studentId = studentId,
+                departmentName = departmentName,
+                serviceId = serviceId,
+                serviceName = serviceName,
+                timeSlotId = timeSlotId,
+                scheduledStartMillis = scheduledStartMillis,
+                dateTimeText = dateTimeText,
+                isLoading = false,
+                isSuccess = false,
+                errorMessage = null
+            )
+        }
+    }
+
+    fun confirm() {
+        val s = _uiState.value
+
+        if (!s.isValid()) {
+            _uiState.update { it.copy(errorMessage = "Seçim bilgileri eksik. Lütfen tekrar deneyin.") }
+            return
+        }
+
+        _uiState.update { it.copy(isLoading = true, errorMessage = null, isSuccess = false) }
+
+        viewModelScope.launch {
+            val result = appointmentRepository.createAppointment(
+                studentId = s.studentId,
+                serviceId = s.serviceId,
+                timeSlotId = s.timeSlotId,
+                scheduledStartMillis = s.scheduledStartMillis
+            )
+
+            if (result.isSuccess) {
+                _uiState.update { it.copy(isLoading = false, isSuccess = true) }
+            } else {
+                val msg = result.exceptionOrNull()?.message ?: "Randevu oluşturulamadı."
+                _uiState.update { it.copy(isLoading = false, errorMessage = msg) }
+            }
+        }
+    }
+
+    fun clearError() {
+        _uiState.update { it.copy(errorMessage = null) }
+    }
+
+    fun consumeSuccess() {
+        _uiState.update { it.copy(isSuccess = false) }
+    }
+}

--- a/app/src/main/java/com/example/studentcenterapp/ui/confirmation/AppointmentConfirmationViewModelFactory.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/confirmation/AppointmentConfirmationViewModelFactory.kt
@@ -1,0 +1,18 @@
+package com.example.studentcenterapp.ui.confirmation
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.example.studentcenterapp.data.appointment.AppointmentRepository
+
+class AppointmentConfirmationViewModelFactory(
+    private val appointmentRepository: AppointmentRepository
+) : ViewModelProvider.Factory {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(AppointmentConfirmationViewModel::class.java)) {
+            return AppointmentConfirmationViewModel(appointmentRepository) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class: ${modelClass.name}")
+    }
+}

--- a/app/src/main/java/com/example/studentcenterapp/ui/confirmation/AppointmentSummaryCard.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/confirmation/AppointmentSummaryCard.kt
@@ -1,0 +1,32 @@
+package com.example.studentcenterapp.ui.confirmation
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import com.example.studentcenterapp.ui.common.ContentCard
+
+@Composable
+fun AppointmentSummaryCard(
+    departmentName: String,
+    serviceText: String,
+    dateTimeText: String,
+    modifier: Modifier = Modifier
+) {
+    ContentCard(modifier = modifier) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Randevu Özeti", fontWeight = FontWeight.Bold)
+            Spacer(Modifier.height(10.dp))
+            Text("Bölüm: ${departmentName.ifBlank { "-" }}")
+            Spacer(Modifier.height(6.dp))
+            Text("Hizmet: ${serviceText.ifBlank { "-" }}")
+            Spacer(Modifier.height(6.dp))
+            Text("Tarih/Saat: ${dateTimeText.ifBlank { "-" }}")
+        }
+    }
+}

--- a/app/src/main/java/com/example/studentcenterapp/ui/screens/AppointmentConfirmationScreen.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/screens/AppointmentConfirmationScreen.kt
@@ -1,0 +1,111 @@
+package com.example.studentcenterapp.ui.screens
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.studentcenterapp.ui.common.AppTopBar
+import com.example.studentcenterapp.ui.common.ErrorView
+import com.example.studentcenterapp.ui.common.LoadingView
+import com.example.studentcenterapp.ui.common.PrimaryButton
+import com.example.studentcenterapp.ui.confirmation.AppointmentConfirmationViewModel
+import com.example.studentcenterapp.ui.confirmation.AppointmentConfirmationViewModelFactory
+import com.example.studentcenterapp.ui.confirmation.AppointmentSummaryCard
+
+@Composable
+fun AppointmentConfirmationScreen(
+    studentId: String,
+    departmentName: String,
+    serviceId: String,
+    serviceName: String,
+    timeSlotId: String,
+    scheduledStartMillis: Long,
+    dateTimeText: String,
+    factory: AppointmentConfirmationViewModelFactory,
+    onBack: () -> Unit,
+    onSuccessNavigate: () -> Unit
+) {
+    val vm: AppointmentConfirmationViewModel = viewModel(factory = factory)
+    val state by vm.uiState.collectAsState()
+
+    // selection bilgilerini 1 kere set et
+    LaunchedEffect(studentId, serviceId, timeSlotId, scheduledStartMillis) {
+        vm.setSelection(
+            studentId = studentId,
+            departmentName = departmentName,
+            serviceId = serviceId,
+            serviceName = serviceName,
+            timeSlotId = timeSlotId,
+            scheduledStartMillis = scheduledStartMillis,
+            dateTimeText = dateTimeText
+        )
+    }
+
+    // success -> navigate (1 kere)
+    LaunchedEffect(state.isSuccess) {
+        if (state.isSuccess) {
+            onSuccessNavigate()
+            vm.consumeSuccess()
+        }
+    }
+
+    Column(
+        modifier = Modifier.fillMaxSize()
+    ) {
+        // ✅ AppTopBar sadece logo gösteriyor, geri butonu yok
+        AppTopBar(title = "Randevu Onayı")
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+        ) {
+            val serviceText = state.serviceName.ifBlank { state.serviceId }
+
+            AppointmentSummaryCard(
+                departmentName = state.departmentName,
+                serviceText = serviceText,
+                dateTimeText = state.dateTimeText
+            )
+
+            Spacer(Modifier.height(16.dp))
+
+            if (state.isLoading) {
+                LoadingView(modifier = Modifier.fillMaxWidth())
+                Spacer(Modifier.height(10.dp))
+            }
+
+            if (state.errorMessage != null) {
+                ErrorView(
+                    message = state.errorMessage ?: "",
+                    onRetry = { vm.clearError() }
+                )
+                Spacer(Modifier.height(10.dp))
+            }
+
+            PrimaryButton(
+                text = if (state.isLoading) "Oluşturuluyor..." else "Onayla",
+                enabled = !state.isLoading,
+                onClick = { vm.confirm() }
+            )
+
+            Spacer(Modifier.height(10.dp))
+
+            // ✅ Geri/iptal işlemi zaten burada
+            PrimaryButton(
+                text = "İptal",
+                enabled = !state.isLoading,
+                onClick = onBack
+            )
+        }
+    }
+}


### PR DESCRIPTION
Description
Implemented the appointment confirmation flow for students.

What’s included

Added AppointmentConfirmationViewModel to hold selected student/service/slot data and call AppointmentRepository.createAppointment().

Added AppointmentConfirmationUiState with basic validation and loading/success/error state handling.

Implemented AppointmentConfirmationScreen to display a summary (department, service, date/time) and provide Confirm / Cancel actions.

Proper error messaging is shown when appointment creation fails.

Acceptance Criteria coverage

✅ Summary data shows department, service and date/time correctly (provided through screen parameters).

✅ Confirm creates an appointment via repository and triggers success navigation.

✅ Errors during creation are displayed via UI state.
