### PR TITLE
fix(navigation): route confirm success to appointment list and preven…

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,6 +54,7 @@ dependencies {
     implementation(libs.androidx.benchmark.traceprocessor)
     implementation(libs.androidx.material3)
     implementation(libs.androidx.compose.material)
+    implementation(libs.places)
 
     testImplementation(libs.junit)
     testImplementation(libs.junit4)

--- a/app/src/main/java/com/example/studentcenterapp/data/student/StudentSession.kt
+++ b/app/src/main/java/com/example/studentcenterapp/data/student/StudentSession.kt
@@ -1,0 +1,9 @@
+package com.example.studentcenterapp.data.student
+
+/**
+ * Basit session holder.
+ * Projede gerçek auth/session yapısı yoksa studentId taşımak için kullanılır.
+ */
+object StudentSession {
+    var currentStudentId: String = ""
+}

--- a/app/src/main/java/com/example/studentcenterapp/navigation/ConfirmationNavKeys.kt
+++ b/app/src/main/java/com/example/studentcenterapp/navigation/ConfirmationNavKeys.kt
@@ -1,0 +1,11 @@
+package com.example.studentcenterapp.navigation
+
+object ConfirmationNavKeys {
+    const val KEY_STUDENT_ID = "studentId"
+    const val KEY_DEPARTMENT_NAME = "departmentName"
+    const val KEY_SERVICE_ID = "serviceId"
+    const val KEY_SERVICE_NAME = "serviceName"
+    const val KEY_TIMESLOT_ID = "timeSlotId"
+    const val KEY_START_MILLIS = "scheduledStartMillis"
+    const val KEY_DATE_TEXT = "dateTimeText"
+}

--- a/app/src/main/java/com/example/studentcenterapp/navigation/StudentCenterNavHost.kt
+++ b/app/src/main/java/com/example/studentcenterapp/navigation/StudentCenterNavHost.kt
@@ -14,11 +14,14 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import com.example.studentcenterapp.data.AppDI
 import com.example.studentcenterapp.data.inmemory.InMemoryDataSource
+import com.example.studentcenterapp.data.student.StudentSession
 import com.example.studentcenterapp.data.timeslot.TimeSlotRepositoryImpl
 import com.example.studentcenterapp.ui.confirmation.AppointmentConfirmationViewModelFactory
 import com.example.studentcenterapp.ui.screens.AppointmentConfirmationScreen
@@ -37,6 +40,7 @@ import com.example.studentcenterapp.ui.staffauth.StaffLoginViewModelFactory
 import com.example.studentcenterapp.ui.staffauth.StaffSignupScreen
 import com.example.studentcenterapp.ui.staffauth.StaffSignupViewModel
 import com.example.studentcenterapp.ui.staffauth.StaffSignupViewModelFactory
+import com.example.studentcenterapp.ui.state.UiState
 import com.example.studentcenterapp.ui.student.ForgotPasswordEmailScreen
 import com.example.studentcenterapp.ui.student.SignupSuccessScreen
 import com.example.studentcenterapp.ui.student.StudentLoginScreen
@@ -52,15 +56,6 @@ import com.example.studentcenterapp.viewmodel.splash.SplashViewModel
 import com.example.studentcenterapp.viewmodel.student.ForgotPasswordViewModel
 import com.example.studentcenterapp.viewmodel.student.StudentLoginViewModel
 import com.example.studentcenterapp.viewmodel.student.StudentSignupViewModel
-
-// ✅ Confirm ekranına veri taşımak için anahtarlar (SavedStateHandle ile)
-private const val KEY_STUDENT_ID = "studentId"
-private const val KEY_DEPARTMENT_NAME = "departmentName"
-private const val KEY_SERVICE_ID = "serviceId"
-private const val KEY_SERVICE_NAME = "serviceName"
-private const val KEY_TIMESLOT_ID = "timeSlotId"
-private const val KEY_START_MILLIS = "scheduledStartMillis"
-private const val KEY_DATE_TEXT = "dateTimeText"
 
 // ✅ Appointments için query param anahtarı
 private const val ARG_STUDENT_ID = "studentId"
@@ -202,7 +197,7 @@ fun StudentCenterNavHost(
         }
 
         // -------------------------
-        // Student flow (Departments -> Services)
+        // Student flow (Departments -> Services -> Slots -> Confirm -> Appointments)
         // -------------------------
         composable(Screen.Departments.route) {
             val vm: DepartmentListViewModel = viewModel(
@@ -216,9 +211,20 @@ fun StudentCenterNavHost(
                 onTabSelected = { tab ->
                     navController.navigate(tab.route) { launchSingleTop = true }
                 },
-                onDepartmentClick = { departmentId ->
+                onDepartmentClick = { departmentId, departmentName ->
+
+                    val handle = navController.currentBackStackEntry?.savedStateHandle
+
+                    // departmentName zaten geldi, state’ten aramana gerek yok
+                    handle?.set(ConfirmationNavKeys.KEY_DEPARTMENT_NAME, departmentName)
+
+                    // studentId (session’dan)
+                    val sid = StudentSession.currentStudentId
+                    handle?.set(ConfirmationNavKeys.KEY_STUDENT_ID, sid)
+
                     navController.navigate("services/$departmentId")
                 }
+
             )
         }
 
@@ -230,7 +236,19 @@ fun StudentCenterNavHost(
             )
             val state by vm.uiState.collectAsState()
 
+            // ✅ Departments entry'sinden gelen değerleri Services entry'sine kopyala
             LaunchedEffect(departmentId) {
+                val prevHandle = navController.previousBackStackEntry?.savedStateHandle
+                val currentHandle = navController.currentBackStackEntry?.savedStateHandle
+
+                val deptName = prevHandle?.get<String>(ConfirmationNavKeys.KEY_DEPARTMENT_NAME).orEmpty()
+                val sid = prevHandle?.get<String>(ConfirmationNavKeys.KEY_STUDENT_ID)
+                    .orEmpty()
+                    .ifBlank { StudentSession.currentStudentId }
+
+                currentHandle?.set(ConfirmationNavKeys.KEY_DEPARTMENT_NAME, deptName)
+                currentHandle?.set(ConfirmationNavKeys.KEY_STUDENT_ID, sid)
+
                 if (departmentId.isNotBlank()) vm.loadServices(departmentId)
             }
 
@@ -240,9 +258,14 @@ fun StudentCenterNavHost(
                 onTabSelected = { tab ->
                     navController.navigate(tab.route) { launchSingleTop = true }
                 },
-                onServiceClick = { serviceId ->
+                onServiceClick = { serviceId, serviceName ->
+                    val handle = navController.currentBackStackEntry?.savedStateHandle
+                    handle?.set(ConfirmationNavKeys.KEY_SERVICE_ID, serviceId)
+                    handle?.set(ConfirmationNavKeys.KEY_SERVICE_NAME, serviceName)
+
                     navController.navigate(TimeSlotDestinations.timeSlotSelectionRoute(serviceId))
                 }
+
             )
         }
 
@@ -253,18 +276,18 @@ fun StudentCenterNavHost(
         )
 
         // -------------------------
-        // ✅ CONFIRM (bizim yaptığımız ekran)
+        // ✅ CONFIRM
         // -------------------------
         composable(Screen.Confirm.route) {
             val prev = navController.previousBackStackEntry?.savedStateHandle
 
-            val studentId = prev?.get<String>(KEY_STUDENT_ID).orEmpty()
-            val departmentName = prev?.get<String>(KEY_DEPARTMENT_NAME).orEmpty()
-            val serviceId = prev?.get<String>(KEY_SERVICE_ID).orEmpty()
-            val serviceName = prev?.get<String>(KEY_SERVICE_NAME).orEmpty()
-            val timeSlotId = prev?.get<String>(KEY_TIMESLOT_ID).orEmpty()
-            val scheduledStartMillis = prev?.get<Long>(KEY_START_MILLIS) ?: 0L
-            val dateTimeText = prev?.get<String>(KEY_DATE_TEXT).orEmpty()
+            val studentId = prev?.get<String>(ConfirmationNavKeys.KEY_STUDENT_ID).orEmpty()
+            val departmentName = prev?.get<String>(ConfirmationNavKeys.KEY_DEPARTMENT_NAME).orEmpty()
+            val serviceId = prev?.get<String>(ConfirmationNavKeys.KEY_SERVICE_ID).orEmpty()
+            val serviceName = prev?.get<String>(ConfirmationNavKeys.KEY_SERVICE_NAME).orEmpty()
+            val timeSlotId = prev?.get<String>(ConfirmationNavKeys.KEY_TIMESLOT_ID).orEmpty()
+            val scheduledStartMillis = prev?.get<Long>(ConfirmationNavKeys.KEY_START_MILLIS) ?: 0L
+            val dateTimeText = prev?.get<String>(ConfirmationNavKeys.KEY_DATE_TEXT).orEmpty()
 
             AppointmentConfirmationScreen(
                 studentId = studentId,
@@ -277,19 +300,30 @@ fun StudentCenterNavHost(
                 factory = AppointmentConfirmationViewModelFactory(AppDI.appointmentRepository),
                 onBack = { navController.popBackStack() },
                 onSuccessNavigate = {
-                    // ✅ studentId’yi route ile taşıyoruz
-                    navController.navigate(appointmentsRoute(studentId)) {
-                        popUpTo(Screen.Confirm.route) { inclusive = true }
-                        launchSingleTop = true
+                    if (studentId.isNotBlank()) {
+                        navController.navigate(appointmentsRoute(studentId)) {
+                            popUpTo(Screen.Confirm.route) { inclusive = true }
+                            launchSingleTop = true
+                        }
+                    } else {
+                        navController.popBackStack()
                     }
                 }
             )
         }
 
         // -------------------------
-        // ✅ APPOINTMENTS (Issue #38)
+        // ✅ APPOINTMENTS
         // -------------------------
-        composable("${Screen.Appointments.route}?$ARG_STUDENT_ID={$ARG_STUDENT_ID}") { backStackEntry ->
+        composable(
+            route = "${Screen.Appointments.route}?$ARG_STUDENT_ID={$ARG_STUDENT_ID}",
+            arguments = listOf(
+                navArgument(ARG_STUDENT_ID) {
+                    type = NavType.StringType
+                    defaultValue = ""
+                }
+            )
+        ) { backStackEntry ->
             val studentId = backStackEntry.arguments?.getString(ARG_STUDENT_ID).orEmpty()
 
             val factory = AppointmentListViewModelFactory(
@@ -299,10 +333,8 @@ fun StudentCenterNavHost(
 
             AppointmentListScreen(
                 factory = factory,
-                onAppointmentClick = { appointmentId ->
-                    // TODO: AppointmentDetailScreen by you (Issue says navigate on click)
-                    // şimdilik placeholder route yoksa popBackStack yapma
-                    // navController.navigate("appointmentDetail/$appointmentId")
+                onAppointmentClick = { _ ->
+                    // TODO AppointmentDetailScreen
                 }
             )
         }
@@ -343,7 +375,6 @@ fun StudentCenterNavHost(
             )
         }
 
-        // ✅ diğer placeholder’lar kalsın (mevcut akışları bozmasın)
         composable(Screen.Services.route) { PlaceholderScreen("Services") }
         composable(Screen.Slots.route) { PlaceholderScreen("Slots") }
         composable(Screen.StaffDashboard.route) { PlaceholderScreen("Staff Dashboard") }

--- a/app/src/main/java/com/example/studentcenterapp/ui/service/ServiceListScreen.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/service/ServiceListScreen.kt
@@ -33,8 +33,8 @@ fun ServiceListScreen(
     state: UiState<List<Service>>,
     currentRoute: String?,
     onTabSelected: (AppTab) -> Unit,
-    onServiceClick: (serviceId: String) -> Unit,
-    onRetry: (() -> Unit)? = null // optional (istersen VM.loadServices bağlarsın)
+    onServiceClick: (serviceId: String, serviceName: String) -> Unit,
+    onRetry: (() -> Unit)? = null
 ) {
     Scaffold(
         topBar = { AppTopBar(title = "Services") },
@@ -85,7 +85,7 @@ fun ServiceListScreen(
                             items(services, key = { it.id }) { service ->
                                 ServiceListItem(
                                     service = service,
-                                    onClick = { onServiceClick(service.id) }
+                                    onClick = { onServiceClick(service.id, service.name) }
                                 )
                             }
                         }

--- a/app/src/main/java/com/example/studentcenterapp/viewmodel/appointment/TimeSlotNavigation.kt
+++ b/app/src/main/java/com/example/studentcenterapp/viewmodel/appointment/TimeSlotNavigation.kt
@@ -6,13 +6,13 @@ import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
+import com.example.studentcenterapp.data.student.StudentSession
 import com.example.studentcenterapp.data.timeslot.TimeSlotRepository
 import com.example.studentcenterapp.model.TimeSlot
-import com.example.studentcenterapp.viewmodel.appointment.TimeSlotCalendarView
-import com.example.studentcenterapp.viewmodel.appointment.TimeSlotCalendarViewModel
-import com.example.studentcenterapp.viewmodel.appointment.TimeSlotCalendarViewModelFactory
-import com.example.studentcenterapp.viewmodel.appointment.TimeSlotSelectionViewModel
-import com.example.studentcenterapp.viewmodel.appointment.TimeSlotSelectionViewModelFactory
+import com.example.studentcenterapp.navigation.ConfirmationNavKeys
+import com.example.studentcenterapp.navigation.Screen
+import java.text.SimpleDateFormat
+import java.util.Locale
 
 /**
  * Time slot flow için route sabitleri.
@@ -55,8 +55,40 @@ fun NavGraphBuilder.timeSlotGraph(
         TimeSlotSelectionScreen(
             viewModel = vm,
             onSlotConfirmed = { slot: TimeSlot ->
-                // TODO: confirmation / appointment akışına bağlanacak
-                // navController.navigate("confirm/${slot.id}")
+
+                // ✅ Services screen entry'sinden (previous) gelen değerler:
+                val prevHandle = navController.previousBackStackEntry?.savedStateHandle
+
+                val studentId = prevHandle
+                    ?.get<String>(ConfirmationNavKeys.KEY_STUDENT_ID)
+                    .orEmpty()
+                    .ifBlank { StudentSession.currentStudentId.ifBlank { "student" } }
+
+                val departmentName =
+                    prevHandle?.get<String>(ConfirmationNavKeys.KEY_DEPARTMENT_NAME).orEmpty()
+
+                val serviceName =
+                    prevHandle?.get<String>(ConfirmationNavKeys.KEY_SERVICE_NAME).orEmpty()
+
+                // ✅ slot -> confirm data
+                val timeSlotId = slot.id
+                val dateTimeText = "${slot.date} ${slot.startTime} - ${slot.endTime}"
+
+                // ✅ TimeSlot modelinde millis yok → date + startTime parse etmeye çalış
+                val scheduledStartMillis = slot.toStartMillisOrNow()
+
+                // ✅ Confirm screen previousBackStackEntry.savedStateHandle okuyacak.
+                // O yüzden veriyi current entry (TimeSlotSelection) handle’a yazıyoruz:
+                val handle = navController.currentBackStackEntry?.savedStateHandle
+                handle?.set(ConfirmationNavKeys.KEY_STUDENT_ID, studentId)
+                handle?.set(ConfirmationNavKeys.KEY_DEPARTMENT_NAME, departmentName)
+                handle?.set(ConfirmationNavKeys.KEY_SERVICE_ID, serviceId) // composable içindeki serviceId
+                handle?.set(ConfirmationNavKeys.KEY_SERVICE_NAME, serviceName)
+                handle?.set(ConfirmationNavKeys.KEY_TIMESLOT_ID, timeSlotId)
+                handle?.set(ConfirmationNavKeys.KEY_START_MILLIS, scheduledStartMillis)
+                handle?.set(ConfirmationNavKeys.KEY_DATE_TEXT, dateTimeText)
+
+                navController.navigate(Screen.Confirm.route)
             },
             onOpenCalendar = {
                 navController.navigate(TimeSlotDestinations.timeSlotCalendarRoute(serviceId))
@@ -83,4 +115,43 @@ fun NavGraphBuilder.timeSlotGraph(
             onBack = { navController.popBackStack() }
         )
     }
+}
+
+/**
+ * ✅ TimeSlot date + startTime -> epoch millis
+ * java.time kullanmıyoruz (desugaring gerektirmesin diye).
+ *
+ * date için birkaç olası format dener:
+ * - yyyy-MM-dd
+ * - dd/MM/yyyy
+ * - dd.MM.yyyy
+ *
+ * startTime formatı: HH:mm (örn: 10:30)
+ *
+ * Parse olmazsa NOW döner.
+ */
+private fun TimeSlot.toStartMillisOrNow(): Long {
+    val dateStr = date.trim()
+    val timeStr = startTime.trim()
+
+    val patterns = listOf(
+        "yyyy-MM-dd HH:mm",
+        "dd/MM/yyyy HH:mm",
+        "dd.MM.yyyy HH:mm"
+    )
+
+    val input = "$dateStr $timeStr"
+
+    for (p in patterns) {
+        try {
+            val sdf = SimpleDateFormat(p, Locale.getDefault())
+            sdf.isLenient = false
+            val parsed = sdf.parse(input)
+            if (parsed != null) return parsed.time
+        } catch (_: Exception) {
+            // try next pattern
+        }
+    }
+
+    return System.currentTimeMillis()
 }

--- a/app/src/main/java/com/example/studentcenterapp/viewmodel/department/DepartmentListScreen.kt
+++ b/app/src/main/java/com/example/studentcenterapp/viewmodel/department/DepartmentListScreen.kt
@@ -56,7 +56,8 @@ fun DepartmentListScreen(
     state: UiState<List<Department>>,
     currentRoute: String?,
     onTabSelected: (AppTab) -> Unit,
-    onDepartmentClick: (String) -> Unit
+    onDepartmentClick: (departmentId: String, departmentName: String) -> Unit
+
 ) {
     Scaffold(
         topBar = { AppTopBar(title = "Departmanlar") },
@@ -88,7 +89,7 @@ fun DepartmentListScreen(
 @Composable
 private fun DepartmentListContent(
     state: UiState<List<Department>>,
-    onDepartmentClick: (String) -> Unit
+    onDepartmentClick:(departmentId: String, departmentName: String) -> Unit
 ) {
     // 8 birimlik liste (state.data içinden gelecek)
 
@@ -164,7 +165,7 @@ private fun DepartmentListContent(
                             DepartmentRow(
                                 title = dep.name,
                                 isSelected = dep.name.contains("Psikolojik"),
-                                onClick = { onDepartmentClick(dep.id) }
+                                onClick = {onDepartmentClick(dep.id, dep.name)}
                             )
                         }
                     }

--- a/app/src/main/java/com/example/studentcenterapp/viewmodel/student/StudentLoginViewModel.kt
+++ b/app/src/main/java/com/example/studentcenterapp/viewmodel/student/StudentLoginViewModel.kt
@@ -8,6 +8,7 @@ import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.example.studentcenterapp.data.AppDI
 import com.example.studentcenterapp.data.student.StudentRepository
+import com.example.studentcenterapp.data.student.StudentSession
 import kotlinx.coroutines.launch
 
 class StudentLoginViewModel(private val repository: StudentRepository) : ViewModel() {
@@ -25,6 +26,7 @@ class StudentLoginViewModel(private val repository: StudentRepository) : ViewMod
             isLoading = false
 
             result.onSuccess {
+                StudentSession.currentStudentId = email.trim()
                 onSuccess()
             }.onFailure {
                 errorMessage = "E-posta/Şifre uyuşmuyor"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ composeMaterial = "1.5.6"
 junit4 = "4.13.2"
 coroutinesTest = "1.8.1"
 turbine = "1.1.0"
+places = "5.1.1"
 
 
 [libraries]
@@ -55,6 +56,7 @@ androidx-compose-material = { group = "androidx.wear.compose", name = "compose-m
 junit4 = { module = "junit:junit", version.ref = "junit4" }
 coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutinesTest" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
+places = { group = "com.google.android.libraries.places", name = "places", version.ref = "places" }
 
 
 [plugins]


### PR DESCRIPTION
Description

Wired the post-confirmation success flow to navigate to AppointmentListScreen.

Ensured back stack correctness to avoid recreating/duplicating appointments on back navigation or recomposition.

Added safe handling for missing navigation arguments (studentId) to prevent crashes.

Newly created appointment is visible immediately by relying on the repository flow updates.

Changes

Navigate to appointments using appointmentsRoute(studentId) on confirm success.

Use popUpTo(confirm) { inclusive = true } + launchSingleTop = true to keep the back stack clean.

Added default value for studentId nav argument on the appointments route.

Updated click callback signatures (department/service) to match navigation data passing.

How to test

Login as student.

Select Department → select Service → choose a Slot → Confirm appointment.

Verify you land on Appointment List and the new appointment appears immediately.

Press back and confirm no duplicate appointment is created and no crash occurs.

Acceptance Criteria

✅ Service → Slot → Confirm → AppointmentList works end-to-end

✅ No duplicated appointments due to back navigation/recomposition

✅ No crashes due to missing arguments