### PR TITLE
feat: add online/office appointment type selection flow

### DIFF
--- a/app/src/main/java/com/example/studentcenterapp/model/Appointment.kt
+++ b/app/src/main/java/com/example/studentcenterapp/model/Appointment.kt
@@ -2,13 +2,14 @@ package com.example.studentcenterapp.model
 
 data class Appointment(
     val id: String,
-    val studentId: String,
+    val studentId: String, // Okul numarası (Örn: 20230604024)
+    val studentName: String = "",
     val staffId: String,
-    val serviceName: String = "", // Listede direkt göstermek için
-    val departmentName: String = "", // "Psikolojik Danışmanlık" gibi
+    val serviceName: String = "",
+    val departmentName: String = "",
     val serviceId: String,
     val timeSlotId: String,
-    val appointmentDate: String = "", // Kolay sıralama ve görüntüleme için
-    val type: String = "office", // Online mı ofis mi?
-    val status: String // "pending" | "approved" | "cancelled"
+    val appointmentDate: String = "",
+    val type: String = "office", // "office" veya "online"
+    val status: String // "pending", "approved", "cancelled"
 )

--- a/app/src/main/java/com/example/studentcenterapp/navigation/StudentCenterNavHost.kt
+++ b/app/src/main/java/com/example/studentcenterapp/navigation/StudentCenterNavHost.kt
@@ -32,6 +32,7 @@ import com.example.studentcenterapp.viewmodel.splash.SplashViewModel
 import com.example.studentcenterapp.viewmodel.student.*
 import com.example.studentcenterapp.ui.appointment.AppointmentDetailRoute
 import com.example.studentcenterapp.ui.student.PasswordResetSuccessScreen
+
 private const val ARG_STUDENT_ID = "studentId"
 
 private fun appointmentsRoute(studentId: String): String {
@@ -202,10 +203,13 @@ fun StudentCenterNavHost(
                 state = state,
                 currentRoute = Screen.Services.route,
                 onTabSelected = { tab -> navController.navigate(tab.route) { launchSingleTop = true } },
-                onServiceClick = { serviceId, serviceName ->
+                onServiceClick = { serviceId, serviceName, type -> // type parametresi eklendi
                     val handle = navController.currentBackStackEntry?.savedStateHandle
                     handle?.set(ConfirmationNavKeys.KEY_SERVICE_ID, serviceId)
                     handle?.set(ConfirmationNavKeys.KEY_SERVICE_NAME, serviceName)
+                    // Seçilen randevu tipini SavedStateHandle'a kaydediyoruz
+                    handle?.set("appointment_type", type)
+
                     navController.navigate(TimeSlotDestinations.timeSlotSelectionRoute(serviceId))
                 },
                 onBackClick = { navController.popBackStack() },
@@ -225,6 +229,9 @@ fun StudentCenterNavHost(
             val scheduledStartMillis = prev?.get<Long>(ConfirmationNavKeys.KEY_START_MILLIS) ?: 0L
             val dateTimeText = prev?.get<String>(ConfirmationNavKeys.KEY_DATE_TEXT).orEmpty()
 
+            // Kaydettiğimiz appointment_type bilgisini alıyoruz
+            val appointmentType = prev?.get<String>("appointment_type") ?: "office"
+
             AppointmentConfirmationScreen(
                 studentId = studentId,
                 departmentName = departmentName,
@@ -233,6 +240,8 @@ fun StudentCenterNavHost(
                 timeSlotId = timeSlotId,
                 scheduledStartMillis = scheduledStartMillis,
                 dateTimeText = dateTimeText,
+                // Onay ekranına bu bilgiyi de paslıyoruz (Gerekirse)
+                // appointmentType = appointmentType,
                 factory = AppointmentConfirmationViewModelFactory(AppDI.appointmentRepository),
                 onBack = { navController.popBackStack() },
                 onSuccessNavigate = {
@@ -269,13 +278,22 @@ fun StudentCenterNavHost(
         }
 
         // --- Staff Dashboard ---
-        composable("staffDashboard/{staffId}?entry={entry}") { backStackEntry ->
+        composable(
+            route = "staffDashboard/{staffId}?entry={entry}",
+            arguments = listOf(
+                navArgument("staffId") { type = NavType.StringType },
+                navArgument("entry") { type = NavType.StringType; defaultValue = "staff" }
+            )
+        ) { backStackEntry ->
             val staffId = backStackEntry.arguments?.getString("staffId").orEmpty()
-            val entry = backStackEntry.arguments?.getString("entry").orEmpty()
+            val entry = backStackEntry.arguments?.getString("entry") ?: "staff"
 
+            // Yetkisiz erişim kontrolü
             if (staffId.isBlank() || entry != "staff") {
-                navController.navigate(Screen.Welcome.route) {
-                    popUpTo(Screen.Welcome.route) { inclusive = true }
+                LaunchedEffect(Unit) {
+                    navController.navigate(Screen.Welcome.route) {
+                        popUpTo(0) { inclusive = true }
+                    }
                 }
                 return@composable
             }
@@ -297,7 +315,7 @@ fun StudentCenterNavHost(
                 onFilterChanged = { vm.onFilterChanged(it) },
                 actionLoading = actionLoading,
                 actionError = actionError,
-                currentRoute = Screen.StaffDashboard.route,
+                currentRoute = "staffDashboard/{staffId}?entry={entry}", // BottomBar aktifliği için
                 onTabSelected = { tab ->
                     navController.navigate(tab.route) { launchSingleTop = true }
                 },

--- a/app/src/main/java/com/example/studentcenterapp/ui/service/ServiceListScreen.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/service/ServiceListScreen.kt
@@ -4,22 +4,23 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBackIosNew
 import androidx.compose.material3.*
-import androidx.compose.runtime.Composable
+import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
 import com.example.studentcenterapp.R
 import com.example.studentcenterapp.model.Service
 import com.example.studentcenterapp.ui.common.*
@@ -29,19 +30,19 @@ import com.example.studentcenterapp.ui.theme.Figtree
 import com.example.studentcenterapp.ui.theme.PrimaryBlue
 import com.example.studentcenterapp.ui.theme.lightText
 
-
-
 @Composable
 fun ServiceListScreen(
     state: UiState<List<Service>>,
     currentRoute: String?,
     onTabSelected: (AppTab) -> Unit,
-    onServiceClick: (serviceId: String, serviceName: String) -> Unit,
+    onServiceClick: (serviceId: String, serviceName: String, type: String) -> Unit,
     onBackClick: () -> Unit,
     onRetry: (() -> Unit)? = null
 ) {
-    // Kaydırma durumunu saklamak için
     val scrollState = rememberScrollState()
+
+    var showTypeSelection by remember { mutableStateOf(false) }
+    var selectedServiceInfo by remember { mutableStateOf<Pair<String, String>?>(null) }
 
     Scaffold(
         topBar = { AppTopBar(title = "") },
@@ -69,7 +70,6 @@ fun ServiceListScreen(
                                 .fillMaxSize()
                                 .padding(horizontal = 24.dp, vertical = 16.dp)
                         ) {
-                            // 1. Geri Butonu
                             Icon(
                                 imageVector = Icons.Default.ArrowBackIosNew,
                                 contentDescription = "Geri",
@@ -79,8 +79,6 @@ fun ServiceListScreen(
                                     .size(24.dp)
                             )
 
-                            // 2. Kaydırılabilir İçerik Alanı
-                            // weight(1f) vererek butonu aşağı iteriz ama içeriği kendi içinde kaydırırız
                             Column(
                                 modifier = Modifier
                                     .weight(1f)
@@ -88,13 +86,9 @@ fun ServiceListScreen(
                                     .fillMaxWidth()
                             ) {
                                 Spacer(modifier = Modifier.height(8.dp))
-
-                                // Dinamik Görsel
                                 val imageResId = getDrawableResource(service.imageName)
                                 Box(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .height(200.dp), // Sabit yükseklik düzeni korur
+                                    modifier = Modifier.fillMaxWidth().height(200.dp),
                                     contentAlignment = Alignment.Center
                                 ) {
                                     Image(
@@ -104,40 +98,88 @@ fun ServiceListScreen(
                                         contentScale = ContentScale.Fit
                                     )
                                 }
-
                                 Spacer(modifier = Modifier.height(24.dp))
-
-                                // Birim Başlığı
                                 Text(
                                     text = service.name,
-                                    style = TextStyle(
-                                        fontFamily = Figtree,
-                                        fontWeight = FontWeight.Bold,
-                                        fontSize = 24.sp
-                                    ),
+                                    style = TextStyle(fontFamily = Figtree, fontWeight = FontWeight.Bold, fontSize = 24.sp),
                                     color = DarkText
                                 )
-
                                 Spacer(modifier = Modifier.height(12.dp))
-
-                                // Birim Açıklaması
                                 Text(
                                     text = service.description,
                                     style = MaterialTheme.typography.labelMedium,
                                     color = lightText,
                                     textAlign = TextAlign.Start
                                 )
-
-                                // Metin bitince butonla arasında nefes payı bırakmak için
                                 Spacer(modifier = Modifier.height(16.dp))
                             }
 
-                            // 3. Sabit "Randevu Al" Butonu
-                            // Column dışında olduğu için her zaman en altta çakılı durur
                             PrimaryButton(
                                 text = "Randevu Al",
-                                onClick = { onServiceClick(service.id, service.name) },
-                                modifier = Modifier.align(Alignment.CenterHorizontally))
+                                onClick = {
+                                    selectedServiceInfo = Pair(service.id, service.name)
+                                    showTypeSelection = true
+                                },
+                                modifier = Modifier.align(Alignment.CenterHorizontally)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (showTypeSelection) {
+        // onDismissRequest içindeki uyarıyı gidermek için if kontrolü eklendi
+        Dialog(onDismissRequest = { if (showTypeSelection) showTypeSelection = false }) {
+            Surface(
+                shape = RoundedCornerShape(28.dp),
+                color = Color(0xFFF2F2F2),
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 8.dp)
+            ) {
+                Column(
+                    modifier = Modifier.padding(24.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
+                    Text(
+                        text = "Lütfen seçim yapınız",
+                        style = TextStyle(fontFamily = Figtree, fontWeight = FontWeight.Bold, fontSize = 18.sp),
+                        color = DarkText,
+                        modifier = Modifier.padding(bottom = 24.dp)
+                    )
+
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(12.dp)
+                    ) {
+                        Button(
+                            onClick = {
+                                val info = selectedServiceInfo
+                                if (info != null) {
+                                    onServiceClick(info.first, info.second, "online")
+                                    if (showTypeSelection) showTypeSelection = false
+                                }
+                            },
+                            modifier = Modifier.weight(1f).height(50.dp),
+                            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF7D7D7D)),
+                            shape = RoundedCornerShape(25.dp)
+                        ) {
+                            Text("Online", color = Color.White, fontWeight = FontWeight.Bold)
+                        }
+
+                        Button(
+                            onClick = {
+                                val info = selectedServiceInfo
+                                if (info != null) {
+                                    onServiceClick(info.first, info.second, "office")
+                                    if (showTypeSelection) showTypeSelection = false
+                                }
+                            },
+                            modifier = Modifier.weight(1f).height(50.dp),
+                            colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF7D7D7D)),
+                            shape = RoundedCornerShape(25.dp)
+                        ) {
+                            Text("Ofis", color = Color.White, fontWeight = FontWeight.Bold)
                         }
                     }
                 }
@@ -145,8 +187,8 @@ fun ServiceListScreen(
         }
     }
 }
-private fun ColumnScope.getDrawableResource(imageName: String?): Int {
 
+private fun ColumnScope.getDrawableResource(imageName: String?): Int {
     return when (imageName) {
         "ic_gelisim" -> R.drawable.ic_gelisim
         "ic_burs" -> R.drawable.ic_burs
@@ -156,8 +198,6 @@ private fun ColumnScope.getDrawableResource(imageName: String?): Int {
         "ic_psikolojik" -> R.drawable.yenipng
         "ic_kultur" -> R.drawable.ic_kultur
         "ic_spor" -> R.drawable.ic_spor
-
-        // Buraya kullandığın tüm ikonları ekle
-        else -> R.drawable.logo_oldx // Varsayılan görsel
+        else -> R.drawable.logo_oldx
     }
 }

--- a/app/src/main/java/com/example/studentcenterapp/ui/staff/StaffDashboardFilters.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/staff/StaffDashboardFilters.kt
@@ -1,79 +1,101 @@
 package com.example.studentcenterapp.ui.staff
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.widthIn
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.studentcenterapp.ui.theme.PrimaryBlue
 
-enum class StaffAppointmentFilter(val label: String) {
-    ACTIVE("Aktif\nRandevular"),
-    PENDING("Onay\nBekliyor"),
-    CANCELLED("İptal Edilen\nRandevular"),
-    ALL("Tüm\nRandevular")
+enum class StaffAppointmentFilter(val label: String, val id: String) {
+    ACTIVE("Aktif\nRandevular", "approved"),
+    PENDING("Onay\nBekliyor", "pending"),
+    CANCELLED("İptal Edilen\nRandevular", "cancelled"),
+    ALL("Tüm\nRandevular", "all")
 }
 
 @Composable
 fun StaffFilterRow(
-    selected: StaffAppointmentFilter,
-    onSelect: (StaffAppointmentFilter) -> Unit
+    selectedFilterId: String,
+    pendingCount: Int = 0,
+    onSelect: (String) -> Unit
 ) {
     Row(
-        horizontalArrangement = Arrangement.spacedBy(10.dp),
-        modifier = Modifier.padding(top = 12.dp, bottom = 10.dp)
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp)
     ) {
-        StaffFilterChip(
-            text = StaffAppointmentFilter.ACTIVE.label,
-            selected = selected == StaffAppointmentFilter.ACTIVE,
-            onClick = { onSelect(StaffAppointmentFilter.ACTIVE) }
-        )
-        StaffFilterChip(
-            text = StaffAppointmentFilter.PENDING.label,
-            selected = selected == StaffAppointmentFilter.PENDING,
-            onClick = { onSelect(StaffAppointmentFilter.PENDING) }
-        )
-        StaffFilterChip(
-            text = StaffAppointmentFilter.CANCELLED.label,
-            selected = selected == StaffAppointmentFilter.CANCELLED,
-            onClick = { onSelect(StaffAppointmentFilter.CANCELLED) }
-        )
-        StaffFilterChip(
-            text = StaffAppointmentFilter.ALL.label,
-            selected = selected == StaffAppointmentFilter.ALL,
-            onClick = { onSelect(StaffAppointmentFilter.ALL) }
-        )
+        StaffAppointmentFilter.entries.forEach { filter ->
+            FilterTabItem(
+                text = filter.label,
+                isSelected = selectedFilterId == filter.id,
+                modifier = Modifier.weight(1f),
+                hasBadge = filter == StaffAppointmentFilter.PENDING && pendingCount > 0,
+                badgeCount = pendingCount,
+                onClick = { onSelect(filter.id) }
+            )
+        }
     }
 }
 
 @Composable
-private fun StaffFilterChip(
+fun FilterTabItem(
     text: String,
-    selected: Boolean,
+    isSelected: Boolean,
+    modifier: Modifier = Modifier,
+    hasBadge: Boolean = false,
+    badgeCount: Int = 0,
     onClick: () -> Unit
 ) {
-    val container = if (selected) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.surface
-    val content = if (selected) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.primary
-
-    Surface(
-        modifier = Modifier
-            .widthIn(min = 72.dp)
-            .clickable(onClick = onClick),
-        shape = MaterialTheme.shapes.small,
-        color = container,
-        contentColor = content,
-        border = if (selected) null else BorderStroke(1.dp, MaterialTheme.colorScheme.primary)
-    ) {
-        Text(
-            text = text,
-            style = MaterialTheme.typography.labelMedium,
-            modifier = Modifier.padding(horizontal = 10.dp, vertical = 8.dp)
-        )
+    Box(modifier = modifier) {
+        Surface(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(50.dp)
+                .clickable { onClick() },
+            color = if (isSelected) PrimaryBlue.copy(alpha = 0.1f) else Color.Transparent,
+            border = BorderStroke(1.dp, PrimaryBlue),
+            shape = RoundedCornerShape(8.dp)
+        ) {
+            Box(contentAlignment = Alignment.Center) {
+                Text(
+                    text = text,
+                    fontSize = 9.sp,
+                    lineHeight = 11.sp,
+                    textAlign = TextAlign.Center,
+                    color = PrimaryBlue,
+                    style = MaterialTheme.typography.labelSmall
+                )
+            }
+        }
+        if (hasBadge && badgeCount > 0) {
+            Box(
+                modifier = Modifier
+                    .size(18.dp)
+                    .align(Alignment.TopEnd)
+                    .offset(x = 4.dp, y = (-4).dp)
+                    .background(Color.Red, CircleShape),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = badgeCount.toString(),
+                    color = Color.White,
+                    fontSize = 10.sp,
+                    style = MaterialTheme.typography.labelSmall
+                )
+            }
+        }
     }
 }

--- a/app/src/main/java/com/example/studentcenterapp/ui/staff/StaffDashboardScreen.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/staff/StaffDashboardScreen.kt
@@ -1,281 +1,258 @@
 package com.example.studentcenterapp.ui.staff
 
-import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
-import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
+import androidx.compose.material.icons.filled.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.compose.ui.window.Dialog
+import com.example.studentcenterapp.R
 import com.example.studentcenterapp.model.Appointment
 import com.example.studentcenterapp.ui.common.*
 import com.example.studentcenterapp.ui.state.UiState
-import com.example.studentcenterapp.ui.theme.PrimaryBlue
-
-private val GrayPanel = Color(0xFFE9E9E9)
-private val GrayCard  = Color(0xFFDADADA)
-private val ChipBlue  = Color(0xFF2EA7D8)
-private val ChipFill  = Color(0xFFDFF3FB)
+import com.example.studentcenterapp.ui.theme.*
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 @Composable
 fun StaffDashboardScreen(
     state: UiState<List<Appointment>>,
-    staffName: String, // ViewModel'den gelen isim
-    selectedFilter: String, // ViewModel'deki currentFilter
-    onFilterChanged: (String) -> Unit, // ViewModel'deki onFilterChanged
+    staffName: String,
+    selectedFilter: String,
+    onFilterChanged: (String) -> Unit,
     actionLoading: Boolean,
     actionError: String?,
     currentRoute: String?,
     onTabSelected: (AppTab) -> Unit,
-    onApprove: (appointmentId: String) -> Unit,
-    onReject: (appointmentId: String) -> Unit
+    onApprove: (String) -> Unit,
+    onReject: (String) -> Unit
 ) {
+    val selectedDate = remember { mutableStateOf(LocalDate.now()) }
+    val showHistoryDialog = remember { mutableStateOf(false) }
+    val selectedApptForHistory = remember { mutableStateOf<Appointment?>(null) }
+    val dateFormatter = remember { DateTimeFormatter.ofPattern("d MMMM, EEEE", Locale("tr")) }
+
     Scaffold(
-        topBar = { AppTopBar(title = "") },
+        topBar = {
+            Box(
+                modifier = Modifier.fillMaxWidth().background(PrimaryBlue).padding(top = 16.dp, bottom = 8.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Image(painter = painterResource(id = R.drawable.logo_oldx), contentDescription = null, modifier = Modifier.size(60.dp, 40.dp))
+            }
+        },
         bottomBar = {
-            AppBottomBar(
-                tabs = bottomTabs,
-                currentRoute = currentRoute,
-                onTabSelected = onTabSelected
-            )
+            AppBottomBar(tabs = bottomTabs, currentRoute = currentRoute, onTabSelected = onTabSelected)
         },
         containerColor = PrimaryBlue
     ) { padding ->
-        ContentCard(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(padding)
-        ) {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = 18.dp, vertical = 16.dp)
-            ) {
-                // Header row
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Text("Merhaba, $staffName.", style = MaterialTheme.typography.titleLarge)
-                    Spacer(Modifier.weight(1f))
-                    Box(
-                        Modifier
-                            .size(36.dp)
-                            .background(Color(0xFFD0D0D0), CircleShape)
-                    )
-                }
+        Column(modifier = Modifier.padding(padding)) {
+            Text(
+                text = "Merhaba, $staffName.",
+                style = MaterialTheme.typography.headlineSmall.copy(fontWeight = FontWeight.Bold),
+                color = Color.White,
+                modifier = Modifier.padding(horizontal = 24.dp, vertical = 16.dp)
+            )
 
-                Surface(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(top = 14.dp),
-                    shape = RoundedCornerShape(18.dp),
-                    color = GrayPanel
-                ) {
-                    Column(Modifier.padding(12.dp)) {
+            ContentCard(modifier = Modifier.fillMaxSize()) {
+                Column(modifier = Modifier.fillMaxSize().padding(top = 20.dp)) {
 
-                        // Filtreleme Kutuları
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.spacedBy(10.dp)
-                        ) {
-                            val pendingCount = if (state is UiState.Success) {
-                                state.data.count { it.status == "pending" }
-                            } else 0
+                    val pendingCount = if (state is UiState.Success) {
+                        state.data.count { it.status == "pending" }
+                    } else 0
 
-                            SegBox("Aktif\nRandevular", selectedFilter == "approved") { onFilterChanged("approved") }
-                            SegBox("Onay\nBekliyor", selectedFilter == "pending", badgeCount = pendingCount) { onFilterChanged("pending") }
-                            SegBox("İptal Edilen\nRandevular", selectedFilter == "cancelled") { onFilterChanged("cancelled") }
-                            SegBox("Tüm\nRandevular", selectedFilter == "all") { onFilterChanged("all") }
+                    StaffFilterRow(selectedFilterId = selectedFilter, pendingCount = pendingCount, onSelect = onFilterChanged)
+
+                    // --- TARİH SEÇİCİ ---
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(vertical = 20.dp, horizontal = 16.dp),
+                        horizontalArrangement = Arrangement.Center,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        IconButton(onClick = { selectedDate.value = selectedDate.value.minusDays(1) }) {
+                            Icon(Icons.Default.ChevronLeft, "Geri", modifier = Modifier.size(28.dp))
                         }
-
-                        // Tarih Satırı (Statik kalsın veya dinamikleştirilebilir)
-                        Row(
-                            modifier = Modifier
-                                .fillMaxWidth()
-                                .padding(top = 10.dp, bottom = 10.dp),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            IconButton(onClick = { }) {
-                                Icon(Icons.AutoMirrored.Filled.KeyboardArrowLeft, contentDescription = "Prev")
-                            }
-                            Spacer(Modifier.weight(1f))
-                            Text("Bugün", style = MaterialTheme.typography.titleMedium)
-                            Spacer(Modifier.weight(1f))
-                            IconButton(onClick = { }) {
-                                Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, contentDescription = "Next")
-                            }
+                        Text(
+                            text = selectedDate.value.format(dateFormatter),
+                            style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
+                            modifier = Modifier.padding(horizontal = 20.dp),
+                            textAlign = TextAlign.Center
+                        )
+                        IconButton(onClick = { selectedDate.value = selectedDate.value.plusDays(1) }) {
+                            Icon(Icons.Default.ChevronRight, "İleri", modifier = Modifier.size(28.dp))
                         }
+                    }
 
-                        if (!actionError.isNullOrBlank()) {
-                            Text(
-                                text = actionError,
-                                color = MaterialTheme.colorScheme.error,
-                                modifier = Modifier.padding(bottom = 8.dp)
-                            )
-                        }
-
-                        when (state) {
-                            is UiState.Loading -> LoadingView(Modifier.fillMaxWidth().padding(vertical = 30.dp))
-                            is UiState.Error -> ErrorView(message = state.message, onRetry = null)
-                            is UiState.Success -> {
-                                if (state.data.isEmpty()) {
-                                    EmptyStateScreen(
-                                        config = EmptyStateConfig(
-                                            title = "Kayıt Bulunamadı",
-                                            message = "Bu kategoriye ait randevu bulunmamaktadır."
-                                        ),
-                                        modifier = Modifier.fillMaxWidth().padding(vertical = 18.dp)
-                                    )
-                                } else {
-                                    LazyColumn(
-                                        verticalArrangement = Arrangement.spacedBy(12.dp),
-                                        modifier = Modifier.fillMaxWidth()
-                                    ) {
-                                        items(state.data, key = { it.id }) { appt ->
-                                            StaffAppointmentCard(
-                                                name = appt.studentId, // İleride studentName ile değiştirilebilir
-                                                time = appt.appointmentDate,
-                                                status = appt.status,
-                                                showActions = (selectedFilter == "pending"),
-                                                onApprove = { onApprove(appt.id) },
-                                                onReject = { onReject(appt.id) }
-                                            )
-                                        }
-                                        item { Spacer(Modifier.height(8.dp)) }
+                    when (state) {
+                        is UiState.Loading -> Box(Modifier.fillMaxSize(), Alignment.Center) { CircularProgressIndicator(color = PrimaryBlue) }
+                        is UiState.Success -> {
+                            if (state.data.isEmpty()) {
+                                EmptyStateScreen(config = EmptyStateConfig("Kayıt Bulunamadı", "Görünecek randevu yok."))
+                            } else {
+                                LazyColumn(
+                                    modifier = Modifier.fillMaxSize().padding(horizontal = 16.dp),
+                                    verticalArrangement = Arrangement.spacedBy(10.dp)
+                                ) {
+                                    items(state.data) { appt ->
+                                        StaffAppointmentCard(
+                                            appointment = appt,
+                                            onApprove = { onApprove(appt.id) },
+                                            onReject = { onReject(appt.id) },
+                                            onShowHistory = {
+                                                selectedApptForHistory.value = appt
+                                                showHistoryDialog.value = true
+                                            }
+                                        )
                                     }
+                                    item { Spacer(modifier = Modifier.height(20.dp)) }
                                 }
                             }
                         }
+                        is UiState.Error -> Box(Modifier.fillMaxSize(), Alignment.Center) { Text(state.message, color = Color.Red) }
                     }
                 }
             }
         }
     }
-}
 
-@Composable
-private fun RowScope.SegBox( // ✅ RowScope ekledik
-    text: String,
-    selected: Boolean,
-    badgeCount: Int = 0,
-    onClick: () -> Unit
-) {
-    Box(modifier = Modifier.weight(1f)) { // ✅ weight'i Box'a taşıdık
-        Surface(
-            modifier = Modifier
-                .fillMaxWidth() // Genişliği Box'a yay
-                .height(46.dp)
-                .clickable(onClick = onClick),
-            shape = RoundedCornerShape(12.dp),
-            color = if (selected) ChipFill else Color.Transparent,
-            border = BorderStroke(1.dp, ChipBlue)
-        ) {
-            Box(contentAlignment = Alignment.Center) {
-                Text(
-                    text = text,
-                    style = MaterialTheme.typography.labelSmall,
-                    color = ChipBlue,
-                    lineHeight = MaterialTheme.typography.labelSmall.lineHeight
-                )
-            }
-        }
-
-        if (badgeCount > 0) {
-            Box(
-                modifier = Modifier
-                    .size(18.dp)
-                    .align(Alignment.TopEnd)
-                    .offset(x = 4.dp, y = (-4).dp)
-                    .background(Color(0xFFE53935), CircleShape),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = badgeCount.toString(),
-                    color = Color.White,
-                    style = MaterialTheme.typography.labelSmall
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun StaffAppointmentCard(
-    name: String,
-    time: String,
-    status: String,
-    showActions: Boolean,
-    onApprove: () -> Unit,
-    onReject: () -> Unit
-) {
-    Surface(
-        modifier = Modifier.fillMaxWidth(),
-        shape = RoundedCornerShape(16.dp),
-        color = GrayCard
-    ) {
-        Column(modifier = Modifier.padding(12.dp)) {
-            Row(verticalAlignment = Alignment.CenterVertically) {
-                Box(Modifier.size(38.dp).background(Color(0xFFBDBDBD), CircleShape))
-                Spacer(Modifier.width(10.dp))
-
-                Column(Modifier.weight(1f)) {
-                    Text(name, style = MaterialTheme.typography.titleMedium)
-                    Text(time, style = MaterialTheme.typography.bodySmall, color = Color(0xFF6A6A6A))
-                }
-                StatusPill(status)
-            }
-
-            if (showActions) {
-                Row(
-                    modifier = Modifier.fillMaxWidth().padding(top = 10.dp),
-                    horizontalArrangement = Arrangement.End
-                ) {
-                    TextButton(onClick = onReject) {
-                        Text("Reddet", color = Color(0xFFE53935))
-                    }
-                    Button(
-                        onClick = onApprove,
-                        colors = ButtonDefaults.buttonColors(containerColor = Color(0xFF19B39A)),
-                        shape = RoundedCornerShape(8.dp)
-                    ) {
-                        Text("Onayla")
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun StatusPill(status: String) {
-    val (label, color) = when (status) {
-        "pending" -> "Onay Bekliyor" to Color(0xFF2EA7D8)
-        "approved" -> "Aktif" to Color(0xFF19B39A)
-        "cancelled" -> "İptal Edildi" to Color(0xFFE53935)
-        else -> status to Color(0xFF2EA7D8)
-    }
-
-    Surface(
-        shape = RoundedCornerShape(50),
-        color = Color.Transparent,
-        border = BorderStroke(1.dp, color)
-    ) {
-        Text(
-            text = label,
-            color = color,
-            style = MaterialTheme.typography.labelMedium,
-            modifier = Modifier.padding(horizontal = 10.dp, vertical = 4.dp)
+    if (showHistoryDialog.value && selectedApptForHistory.value != null) {
+        AppointmentHistoryDialog(
+            appointment = selectedApptForHistory.value!!,
+            onDismiss = { showHistoryDialog.value = false }
         )
+    }
+}
+
+@Composable
+fun StaffAppointmentCard(
+    appointment: Appointment,
+    onApprove: () -> Unit,
+    onReject: () -> Unit,
+    onShowHistory: () -> Unit
+) {
+    var isExpanded by remember { mutableStateOf(false) }
+
+    Card(
+        modifier = Modifier.fillMaxWidth().clickable { isExpanded = !isExpanded },
+        shape = RoundedCornerShape(20.dp),
+        colors = CardDefaults.cardColors(containerColor = Color(0xFFF2F2F2))
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(Icons.Default.AccountCircle, null, Modifier.size(45.dp), Color.Gray)
+                Spacer(modifier = Modifier.width(12.dp))
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(text = appointment.studentName, style = MaterialTheme.typography.titleSmall, color = DarkText)
+                    Text(text = appointment.appointmentDate, style = MaterialTheme.typography.bodySmall, color = lightText)
+                }
+
+                StatusBadge(status = appointment.status)
+                Icon(imageVector = if (isExpanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown, contentDescription = null, tint = Color.Gray)
+            }
+
+            AnimatedVisibility(visible = isExpanded) {
+                Column(modifier = Modifier.padding(top = 16.dp, start = 57.dp)) {
+                    // Figma'daki Sade Tasarım: Sadece Öğrenci No ve Son Randevu Bilgisi
+                    DetailInfoItem(icon = Icons.Default.Badge, text = appointment.studentId)
+                    Spacer(modifier = Modifier.height(10.dp))
+                    DetailInfoItem(icon = Icons.Default.CalendarToday, text = "Son Randevu Tarihi: --")
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.End, verticalAlignment = Alignment.CenterVertically) {
+                        if (appointment.status == "pending") {
+                            IconButton(onClick = onApprove) { Icon(Icons.Default.CheckCircle, null, Modifier.size(32.dp), Color(0xFF48C9B0)) }
+                            IconButton(onClick = onReject) { Icon(Icons.Default.Cancel, null, Modifier.size(32.dp), Color.Red) }
+                        }
+
+                        Button(
+                            onClick = onShowHistory,
+                            colors = ButtonDefaults.buttonColors(containerColor = Color.Gray),
+                            shape = RoundedCornerShape(8.dp),
+                            modifier = Modifier.height(32.dp),
+                            contentPadding = PaddingValues(horizontal = 12.dp)
+                        ) {
+                            Text("Randevu Geçmişi", fontSize = 10.sp, color = Color.White)
+                        }
+
+                        if (appointment.status != "pending") {
+                            Spacer(modifier = Modifier.width(8.dp))
+                            IconButton(onClick = { }) { Icon(Icons.Default.Chat, null, tint = Color.Gray) }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun AppointmentHistoryDialog(
+    appointment: Appointment,
+    onDismiss: () -> Unit
+) {
+    Dialog(onDismissRequest = onDismiss) {
+        Surface(modifier = Modifier.fillMaxWidth().padding(16.dp), shape = RoundedCornerShape(28.dp), color = Color(0xFFF2F2F2)) {
+            Column(modifier = Modifier.padding(24.dp), verticalArrangement = Arrangement.spacedBy(16.dp)) {
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(Icons.Default.AccountCircle, null, Modifier.size(48.dp), Color.Gray)
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Column {
+                        Text(text = appointment.studentName, style = MaterialTheme.typography.titleMedium, fontWeight = FontWeight.Bold)
+                        Text(text = appointment.studentId, style = MaterialTheme.typography.bodySmall, color = Color.Gray)
+                    }
+                }
+
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Icon(Icons.Default.History, null, Modifier.size(18.dp), Color.Black)
+                    Spacer(modifier = Modifier.width(8.dp))
+                    Text(text = "Randevu Hareketleri", fontSize = 14.sp, fontWeight = FontWeight.Bold)
+                }
+
+                HorizontalDivider(color = Color.LightGray, thickness = 0.5.dp)
+
+                Text(text = "Daha önce randevu kaydı bulunmamaktadır.", fontSize = 12.sp, color = Color.DarkGray)
+
+                TextButton(onClick = onDismiss, modifier = Modifier.align(Alignment.End)) {
+                    Text("Kapat", color = PrimaryBlue, fontWeight = FontWeight.Bold)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun DetailInfoItem(icon: androidx.compose.ui.graphics.vector.ImageVector, text: String) {
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        Icon(icon, null, Modifier.size(16.dp), Color.Gray)
+        Spacer(modifier = Modifier.width(8.dp))
+        Text(text = text, fontSize = 12.sp, color = Color.DarkGray)
+    }
+}
+
+@Composable
+fun StatusBadge(status: String) {
+    val (label, color) = when (status) {
+        "approved" -> "Aktif" to Color(0xFF48C9B0)
+        "pending" -> "Onay" to Color(0xFFFF7043)
+        "cancelled" -> "İptal" to Color(0xFFE91E63)
+        else -> "Bilinmiyor" to Color.Gray
+    }
+    Surface(color = color, shape = RoundedCornerShape(12.dp)) {
+        Text(text = label, color = Color.White, fontSize = 10.sp, modifier = Modifier.padding(horizontal = 8.dp, vertical = 4.dp))
     }
 }

--- a/app/src/main/java/com/example/studentcenterapp/ui/staff/StaffDashboardViewModel.kt
+++ b/app/src/main/java/com/example/studentcenterapp/ui/staff/StaffDashboardViewModel.kt
@@ -17,19 +17,16 @@ class StaffDashboardViewModel(
     private val repository: StaffRepository
 ) : ViewModel() {
 
-    // Firestore'dan gelen ham listeyi burada tutuyoruz
     private var allAppointments: List<Appointment> = emptyList()
 
-    // UI'ın dinlediği filtrelenmiş liste
     private val _uiState = MutableStateFlow<UiState<List<Appointment>>>(UiState.Loading)
     val uiState: StateFlow<UiState<List<Appointment>>> = _uiState.asStateFlow()
 
-    // Personelin ismi (Firestore 'users' koleksiyonundan)
     private val _staffName = MutableStateFlow("Personel")
     val staffName: StateFlow<String> = _staffName.asStateFlow()
 
-    // Şu an seçili olan filtre (Default: pending)
-    private val _currentFilter = MutableStateFlow("pending")
+    // Görseldeki default filtre: Aktif Randevular (approved)
+    private val _currentFilter = MutableStateFlow("approved")
     val currentFilter: StateFlow<String> = _currentFilter.asStateFlow()
 
     private val _actionLoading = MutableStateFlow(false)
@@ -59,49 +56,32 @@ class StaffDashboardViewModel(
 
     private fun observeAppointments() {
         viewModelScope.launch {
-            _uiState.value = UiState.Loading
-            try {
-                // Repository üzerinden personelin tüm randevularını canlı dinle
-                repository.getPendingAppointmentsForStaff(staffId).collect { list ->
-                    allAppointments = list
-                    applyFilter(_currentFilter.value) // Veri geldiğinde mevcut filtreyi uygula
-                }
-            } catch (e: Exception) {
-                _uiState.value = UiState.Error(e.message ?: "Veriler yüklenemedi")
+            repository.getPendingAppointmentsForStaff(staffId).collect { list ->
+                allAppointments = list
+                applyFilter(_currentFilter.value)
             }
         }
     }
 
-    // Ekrandaki kutulara tıklandığında bu fonksiyon çağrılacak
     fun onFilterChanged(newStatus: String) {
         _currentFilter.value = newStatus
         applyFilter(newStatus)
     }
 
     private fun applyFilter(status: String) {
-        val filteredList = if (status == "all") {
-            allAppointments
-        } else {
-            allAppointments.filter { it.status == status }
-        }
+        val filteredList = if (status == "all") allAppointments else allAppointments.filter { it.status == status }
         _uiState.value = UiState.Success(filteredList)
     }
 
-    fun approve(appointmentId: String) = updateStatus(appointmentId, true)
-    fun reject(appointmentId: String) = updateStatus(appointmentId, false)
+    fun approve(id: String) = updateStatus(id, true)
+    fun reject(id: String) = updateStatus(id, false)
 
-    private fun updateStatus(appointmentId: String, isApprove: Boolean) {
+    private fun updateStatus(id: String, isApprove: Boolean) {
         viewModelScope.launch {
             _actionLoading.value = true
-            _actionError.value = null
-
-            val result = if (isApprove) repository.approveAppointment(appointmentId)
-            else repository.rejectAppointment(appointmentId)
-
+            val result = if (isApprove) repository.approveAppointment(id) else repository.rejectAppointment(id)
             _actionLoading.value = false
-            if (result.isFailure) {
-                _actionError.value = result.exceptionOrNull()?.message
-            }
+            if (result.isFailure) _actionError.value = result.exceptionOrNull()?.message
         }
     }
 }


### PR DESCRIPTION
- Integrated appointment type selection dialog in ServiceListScreen based on Figma designs.
- Updated ServiceListScreen navigation callback to handle 'online' and 'office' types.
- Enhanced StudentCenterNavHost to pass the selected appointment type using SavedStateHandle.
- Fixed IDE warnings regarding unused state values in the type selection dialog.